### PR TITLE
fix(hook): accidentially recursive call when deligating depricated function call to new version

### DIFF
--- a/jo_libs/modules/hook/shared.lua
+++ b/jo_libs/modules/hook/shared.lua
@@ -75,7 +75,7 @@ end
 -- DEPRECIATED
 -------------
 function jo.hook.RegisterFilter(...)
-  jo.hook.RegisterFilter(...)
+  jo.hook.registerFilter(...)
   CreateThread(function()
     Wait(3000)
     oprint('RegisterFilter with "R" in uppercase is depreciated. Use registerFilter with "r" in lowercase !')


### PR DESCRIPTION
In some docs (https://docs.jumpon-studios.com/RedM/stable-horsetaming) the `RegisterFilter` function is referenced instead of `registerFilter` and will trigger an error because the `RegisterFilter` function is calling itself instead of `registerFilter` with the lower letter **'r'** 