### PR TITLE
bugfix(disappearing hair, beards, teeth, fix overlays)

### DIFF
--- a/jo_libs/modules/framework-bridge/hairs.lua
+++ b/jo_libs/modules/framework-bridge/hairs.lua
@@ -1,0 +1,14323 @@
+hairs_list = {
+	['female'] = {
+		['hair'] = {
+			[1] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3887861344,
+					['hash_dec_signed'] = -407105952,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1484585410,
+					['hash_dec_signed'] = 1484585410,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 368546563,
+					['hash_dec_signed'] = 368546563,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2859319420,
+					['hash_dec_signed'] = -1435647876,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 121629299,
+					['hash_dec_signed'] = 121629299,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1297587677,
+					['hash_dec_signed'] = 1297587677,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3465481065,
+					['hash_dec_signed'] = -829486231,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1109845536,
+					['hash_dec_signed'] = 1109845536,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2043513452,
+					['hash_dec_signed'] = 2043513452,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1681968008,
+					['hash_dec_signed'] = 1681968008,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1672340786,
+					['hash_dec_signed'] = 1672340786,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3562168289,
+					['hash_dec_signed'] = -732799007,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2943428584,
+					['hash_dec_signed'] = -1351538712,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3998232755,
+					['hash_dec_signed'] = -296734541,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 406510339,
+					['hash_dec_signed'] = 406510339,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4265445050,
+					['hash_dec_signed'] = -29522246,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3777952736,
+					['hash_dec_signed'] = -517014560,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_001_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[2] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 477432347,
+					['hash_dec_signed'] = 477432347,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1494417353,
+					['hash_dec_signed'] = 1494417353,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 306287596,
+					['hash_dec_signed'] = 306287596,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4257741802,
+					['hash_dec_signed'] = -37225494,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4174365333,
+					['hash_dec_signed'] = -120601963,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4038240267,
+					['hash_dec_signed'] = -256727029,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 133887219,
+					['hash_dec_signed'] = 133887219,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3108769963,
+					['hash_dec_signed'] = -1186197333,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 272798698,
+					['hash_dec_signed'] = 272798698,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2906995497,
+					['hash_dec_signed'] = -1387971799,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3919887687,
+					['hash_dec_signed'] = -375079609,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4251904735,
+					['hash_dec_signed'] = -43062561,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 117375707,
+					['hash_dec_signed'] = 117375707,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2694262247,
+					['hash_dec_signed'] = -1600705049,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 504480234,
+					['hash_dec_signed'] = 504480234,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2573973278,
+					['hash_dec_signed'] = -1720994018,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 791990600,
+					['hash_dec_signed'] = 791990600,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_002_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[3] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 480662374,
+					['hash_dec_signed'] = 480662374,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1036145925,
+					['hash_dec_signed'] = 1036145925,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1750698878,
+					['hash_dec_signed'] = 1750698878,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3092705735,
+					['hash_dec_signed'] = -1202261561,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3282065285,
+					['hash_dec_signed'] = -1012902011,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4188126325,
+					['hash_dec_signed'] = -106840971,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2973769959,
+					['hash_dec_signed'] = -1321197337,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1240740249,
+					['hash_dec_signed'] = 1240740249,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3333621563,
+					['hash_dec_signed'] = -961345733,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2331587843,
+					['hash_dec_signed'] = -1963379453,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3230459495,
+					['hash_dec_signed'] = -1064507801,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1291564328,
+					['hash_dec_signed'] = 1291564328,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4262556694,
+					['hash_dec_signed'] = -32410602,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1287454364,
+					['hash_dec_signed'] = 1287454364,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2477355288,
+					['hash_dec_signed'] = -1817612008,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3625715216,
+					['hash_dec_signed'] = -669252080,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2024813755,
+					['hash_dec_signed'] = 2024813755,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_003_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[4] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3981330188,
+					['hash_dec_signed'] = -313637108,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2384771792,
+					['hash_dec_signed'] = -1910195504,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2465052044,
+					['hash_dec_signed'] = -1829915252,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 815986484,
+					['hash_dec_signed'] = 815986484,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 179763942,
+					['hash_dec_signed'] = 179763942,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2378642311,
+					['hash_dec_signed'] = -1916324985,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4053416136,
+					['hash_dec_signed'] = -241551160,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1597549589,
+					['hash_dec_signed'] = 1597549589,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2742505059,
+					['hash_dec_signed'] = -1552462237,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1030010203,
+					['hash_dec_signed'] = 1030010203,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3075144371,
+					['hash_dec_signed'] = -1219822925,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2658995668,
+					['hash_dec_signed'] = -1635971628,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2970541519,
+					['hash_dec_signed'] = -1324425777,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2623186434,
+					['hash_dec_signed'] = -1671780862,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 507190568,
+					['hash_dec_signed'] = 507190568,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1895061720,
+					['hash_dec_signed'] = 1895061720,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1089186542,
+					['hash_dec_signed'] = 1089186542,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_004_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[5] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4056827265,
+					['hash_dec_signed'] = -238140031,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1805787437,
+					['hash_dec_signed'] = 1805787437,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1533949009,
+					['hash_dec_signed'] = 1533949009,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3307855581,
+					['hash_dec_signed'] = -987111715,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2490382504,
+					['hash_dec_signed'] = -1804584792,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2682623609,
+					['hash_dec_signed'] = -1612343687,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3133865747,
+					['hash_dec_signed'] = -1161101549,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 740194192,
+					['hash_dec_signed'] = 740194192,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4197097800,
+					['hash_dec_signed'] = -97869496,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4326228,
+					['hash_dec_signed'] = 4326228,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1318574398,
+					['hash_dec_signed'] = 1318574398,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2793052570,
+					['hash_dec_signed'] = -1501914726,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3192927154,
+					['hash_dec_signed'] = -1102040142,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2131868179,
+					['hash_dec_signed'] = 2131868179,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3381261,
+					['hash_dec_signed'] = 3381261,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1805882815,
+					['hash_dec_signed'] = 1805882815,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3345138613,
+					['hash_dec_signed'] = -949828683,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_005_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[6] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4213681404,
+					['hash_dec_signed'] = -81285892,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 6301841,
+					['hash_dec_signed'] = 6301841,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1141776368,
+					['hash_dec_signed'] = 1141776368,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1923744857,
+					['hash_dec_signed'] = 1923744857,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2392395103,
+					['hash_dec_signed'] = -1902572193,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 90307511,
+					['hash_dec_signed'] = 90307511,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1320043540,
+					['hash_dec_signed'] = 1320043540,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3312528563,
+					['hash_dec_signed'] = -982438733,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2403638681,
+					['hash_dec_signed'] = -1891328615,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2879698054,
+					['hash_dec_signed'] = -1415269242,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4064477163,
+					['hash_dec_signed'] = -230490133,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1438066731,
+					['hash_dec_signed'] = 1438066731,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3684813256,
+					['hash_dec_signed'] = -610154040,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1715649495,
+					['hash_dec_signed'] = 1715649495,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1709715848,
+					['hash_dec_signed'] = 1709715848,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2296822697,
+					['hash_dec_signed'] = -1998144599,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1678607713,
+					['hash_dec_signed'] = 1678607713,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_006_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[7] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3157863298,
+					['hash_dec_signed'] = -1137103998,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 786747692,
+					['hash_dec_signed'] = 786747692,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2986650291,
+					['hash_dec_signed'] = -1308317005,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2582796019,
+					['hash_dec_signed'] = -1712171277,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3248894398,
+					['hash_dec_signed'] = -1046072898,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1609951869,
+					['hash_dec_signed'] = 1609951869,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1538423250,
+					['hash_dec_signed'] = 1538423250,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3591842093,
+					['hash_dec_signed'] = -703125203,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 332147902,
+					['hash_dec_signed'] = 332147902,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 987875961,
+					['hash_dec_signed'] = 987875961,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3254346233,
+					['hash_dec_signed'] = -1040621063,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3936378550,
+					['hash_dec_signed'] = -358588746,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2975650911,
+					['hash_dec_signed'] = -1319316385,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2020080935,
+					['hash_dec_signed'] = 2020080935,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 777331155,
+					['hash_dec_signed'] = 777331155,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2733055824,
+					['hash_dec_signed'] = -1561911472,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1325054645,
+					['hash_dec_signed'] = 1325054645,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_007_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[8] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2506655238,
+					['hash_dec_signed'] = -1788312058,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1784851286,
+					['hash_dec_signed'] = 1784851286,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3343865606,
+					['hash_dec_signed'] = -951101690,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4240949692,
+					['hash_dec_signed'] = -54017604,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1852460277,
+					['hash_dec_signed'] = 1852460277,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 64305580,
+					['hash_dec_signed'] = 64305580,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2678921888,
+					['hash_dec_signed'] = -1616045408,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2130053094,
+					['hash_dec_signed'] = 2130053094,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 348879995,
+					['hash_dec_signed'] = 348879995,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3091858821,
+					['hash_dec_signed'] = -1203108475,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2768496504,
+					['hash_dec_signed'] = -1526470792,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1925775192,
+					['hash_dec_signed'] = 1925775192,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4150392632,
+					['hash_dec_signed'] = -144574664,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 980632813,
+					['hash_dec_signed'] = 980632813,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4088826378,
+					['hash_dec_signed'] = -206140918,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1617935389,
+					['hash_dec_signed'] = 1617935389,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2475770015,
+					['hash_dec_signed'] = -1819197281,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_008_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[9] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4232584509,
+					['hash_dec_signed'] = -62382787,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2614489760,
+					['hash_dec_signed'] = -1680477536,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2665316008,
+					['hash_dec_signed'] = -1629651288,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2701307984,
+					['hash_dec_signed'] = -1593659312,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 68508030,
+					['hash_dec_signed'] = 68508030,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3554016275,
+					['hash_dec_signed'] = -740951021,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 869323742,
+					['hash_dec_signed'] = 869323742,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2852996561,
+					['hash_dec_signed'] = -1441970735,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3591519556,
+					['hash_dec_signed'] = -703447740,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1043469528,
+					['hash_dec_signed'] = 1043469528,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1091490859,
+					['hash_dec_signed'] = 1091490859,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3925344667,
+					['hash_dec_signed'] = -369622629,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2181613711,
+					['hash_dec_signed'] = -2113353585,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 169691417,
+					['hash_dec_signed'] = 169691417,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2862766726,
+					['hash_dec_signed'] = -1432200570,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3502568652,
+					['hash_dec_signed'] = -792398644,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3350274069,
+					['hash_dec_signed'] = -944693227,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_009_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[10] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 121268493,
+					['hash_dec_signed'] = 121268493,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2888306899,
+					['hash_dec_signed'] = -1406660397,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 658872627,
+					['hash_dec_signed'] = 658872627,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2822112650,
+					['hash_dec_signed'] = -1472854646,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1548901968,
+					['hash_dec_signed'] = 1548901968,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 497657806,
+					['hash_dec_signed'] = 497657806,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2088915818,
+					['hash_dec_signed'] = 2088915818,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3768957540,
+					['hash_dec_signed'] = -526009756,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3504497472,
+					['hash_dec_signed'] = -790469824,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 149047576,
+					['hash_dec_signed'] = 149047576,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 118889588,
+					['hash_dec_signed'] = 118889588,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 730317751,
+					['hash_dec_signed'] = 730317751,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2540713625,
+					['hash_dec_signed'] = -1754253671,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3088833281,
+					['hash_dec_signed'] = -1206134015,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1517523662,
+					['hash_dec_signed'] = 1517523662,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 221566106,
+					['hash_dec_signed'] = 221566106,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1620016488,
+					['hash_dec_signed'] = 1620016488,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_010_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[11] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2682500828,
+					['hash_dec_signed'] = -1612466468,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1131227064,
+					['hash_dec_signed'] = 1131227064,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3294975314,
+					['hash_dec_signed'] = -999991982,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 134135711,
+					['hash_dec_signed'] = 134135711,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3296704226,
+					['hash_dec_signed'] = -998263070,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 295404001,
+					['hash_dec_signed'] = 295404001,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 388083084,
+					['hash_dec_signed'] = 388083084,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2215494161,
+					['hash_dec_signed'] = -2079473135,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2054194665,
+					['hash_dec_signed'] = 2054194665,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1847915859,
+					['hash_dec_signed'] = 1847915859,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2116287140,
+					['hash_dec_signed'] = 2116287140,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3340203342,
+					['hash_dec_signed'] = -954763954,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2574261968,
+					['hash_dec_signed'] = -1720705328,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4112674043,
+					['hash_dec_signed'] = -182293253,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2840738130,
+					['hash_dec_signed'] = -1454229166,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1084504086,
+					['hash_dec_signed'] = 1084504086,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3530988117,
+					['hash_dec_signed'] = -763979179,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_011_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[12] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3055193076,
+					['hash_dec_signed'] = -1239774220,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2435277382,
+					['hash_dec_signed'] = -1859689914,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2859896933,
+					['hash_dec_signed'] = -1435070363,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3481775652,
+					['hash_dec_signed'] = -813191644,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1140310123,
+					['hash_dec_signed'] = 1140310123,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 617432326,
+					['hash_dec_signed'] = 617432326,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2122306480,
+					['hash_dec_signed'] = 2122306480,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3402815477,
+					['hash_dec_signed'] = -892151819,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2714899305,
+					['hash_dec_signed'] = -1580067991,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4206016641,
+					['hash_dec_signed'] = -88950655,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3307620636,
+					['hash_dec_signed'] = -987346660,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2153818139,
+					['hash_dec_signed'] = -2141149157,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3241568002,
+					['hash_dec_signed'] = -1053399294,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 371458575,
+					['hash_dec_signed'] = 371458575,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1416911728,
+					['hash_dec_signed'] = 1416911728,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1894250564,
+					['hash_dec_signed'] = 1894250564,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 203301940,
+					['hash_dec_signed'] = 203301940,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_012_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[13] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1613479242,
+					['hash_dec_signed'] = 1613479242,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1847208808,
+					['hash_dec_signed'] = 1847208808,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2870210283,
+					['hash_dec_signed'] = -1424757013,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1176805492,
+					['hash_dec_signed'] = 1176805492,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 681141339,
+					['hash_dec_signed'] = 681141339,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 253209781,
+					['hash_dec_signed'] = 253209781,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2152524497,
+					['hash_dec_signed'] = -2142442799,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1771180828,
+					['hash_dec_signed'] = 1771180828,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2437706505,
+					['hash_dec_signed'] = -1857260791,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 55480155,
+					['hash_dec_signed'] = 55480155,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 942186406,
+					['hash_dec_signed'] = 942186406,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2370105847,
+					['hash_dec_signed'] = -1924861449,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1715823207,
+					['hash_dec_signed'] = 1715823207,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1845329994,
+					['hash_dec_signed'] = 1845329994,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1237816835,
+					['hash_dec_signed'] = 1237816835,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3313261739,
+					['hash_dec_signed'] = -981705557,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 91425386,
+					['hash_dec_signed'] = 91425386,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_013_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[14] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1560191357,
+					['hash_dec_signed'] = 1560191357,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 396308894,
+					['hash_dec_signed'] = 396308894,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2561969623,
+					['hash_dec_signed'] = -1732997673,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4198107247,
+					['hash_dec_signed'] = -96860049,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1096242045,
+					['hash_dec_signed'] = 1096242045,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4134361312,
+					['hash_dec_signed'] = -160605984,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3066310816,
+					['hash_dec_signed'] = -1228656480,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4165008168,
+					['hash_dec_signed'] = -129959128,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 617200186,
+					['hash_dec_signed'] = 617200186,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1377126878,
+					['hash_dec_signed'] = 1377126878,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1046968383,
+					['hash_dec_signed'] = 1046968383,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4082835931,
+					['hash_dec_signed'] = -212131365,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 473172620,
+					['hash_dec_signed'] = 473172620,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2828332613,
+					['hash_dec_signed'] = -1466634683,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1011255576,
+					['hash_dec_signed'] = 1011255576,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3014032403,
+					['hash_dec_signed'] = -1280934893,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2110206217,
+					['hash_dec_signed'] = 2110206217,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_014_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[18] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1687567099,
+					['hash_dec_signed'] = 1687567099,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[15] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2295166995,
+					['hash_dec_signed'] = -1999800301,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1806828653,
+					['hash_dec_signed'] = 1806828653,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3362763558,
+					['hash_dec_signed'] = -932203738,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3918122422,
+					['hash_dec_signed'] = -376844874,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4204799435,
+					['hash_dec_signed'] = -90167861,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4027844274,
+					['hash_dec_signed'] = -267123022,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2643548282,
+					['hash_dec_signed'] = -1651419014,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2893207230,
+					['hash_dec_signed'] = -1401760066,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 797659203,
+					['hash_dec_signed'] = 797659203,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3185496483,
+					['hash_dec_signed'] = -1109470813,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2602466330,
+					['hash_dec_signed'] = -1692500966,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3254757403,
+					['hash_dec_signed'] = -1040209893,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 93967432,
+					['hash_dec_signed'] = 93967432,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1151816609,
+					['hash_dec_signed'] = 1151816609,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1999553541,
+					['hash_dec_signed'] = 1999553541,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2222714901,
+					['hash_dec_signed'] = -2072252395,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2467289897,
+					['hash_dec_signed'] = -1827677399,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_015_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[16] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4207646230,
+					['hash_dec_signed'] = -87321066,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 140277730,
+					['hash_dec_signed'] = 140277730,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3319809939,
+					['hash_dec_signed'] = -975157357,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2109232330,
+					['hash_dec_signed'] = 2109232330,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2651279642,
+					['hash_dec_signed'] = -1643687654,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 218037466,
+					['hash_dec_signed'] = 218037466,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1909298657,
+					['hash_dec_signed'] = 1909298657,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3147826577,
+					['hash_dec_signed'] = -1147140719,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2749478668,
+					['hash_dec_signed'] = -1545488628,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4278118737,
+					['hash_dec_signed'] = -16848559,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2553933494,
+					['hash_dec_signed'] = -1741033802,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2741154357,
+					['hash_dec_signed'] = -1553812939,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3284423172,
+					['hash_dec_signed'] = -1010544124,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4013316119,
+					['hash_dec_signed'] = -281651177,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2698245511,
+					['hash_dec_signed'] = -1596721785,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1696004030,
+					['hash_dec_signed'] = 1696004030,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3585910776,
+					['hash_dec_signed'] = -709056520,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_016_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[17] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4178651078,
+					['hash_dec_signed'] = -116316218,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3916928095,
+					['hash_dec_signed'] = -378039201,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1949113658,
+					['hash_dec_signed'] = 1949113658,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 124757932,
+					['hash_dec_signed'] = 124757932,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4189168743,
+					['hash_dec_signed'] = -105798553,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3208302102,
+					['hash_dec_signed'] = -1086665194,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2771921242,
+					['hash_dec_signed'] = -1523046054,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 220334858,
+					['hash_dec_signed'] = 220334858,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4091163093,
+					['hash_dec_signed'] = -203804203,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2391001669,
+					['hash_dec_signed'] = -1903965627,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3550664076,
+					['hash_dec_signed'] = -744303220,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 480931427,
+					['hash_dec_signed'] = 480931427,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 68102926,
+					['hash_dec_signed'] = 68102926,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 336556257,
+					['hash_dec_signed'] = 336556257,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1763716249,
+					['hash_dec_signed'] = 1763716249,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 94629394,
+					['hash_dec_signed'] = 94629394,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 826534200,
+					['hash_dec_signed'] = 826534200,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_017_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[18] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4210106379,
+					['hash_dec_signed'] = -84860917,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4180393878,
+					['hash_dec_signed'] = -114573418,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 160919686,
+					['hash_dec_signed'] = 160919686,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 769159816,
+					['hash_dec_signed'] = 769159816,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2613289974,
+					['hash_dec_signed'] = -1681677322,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3639616535,
+					['hash_dec_signed'] = -655350761,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3035886457,
+					['hash_dec_signed'] = -1259080839,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 888815427,
+					['hash_dec_signed'] = 888815427,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3898338623,
+					['hash_dec_signed'] = -396628673,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1269897867,
+					['hash_dec_signed'] = 1269897867,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3671356027,
+					['hash_dec_signed'] = -623611269,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4149074677,
+					['hash_dec_signed'] = -145892619,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1941280070,
+					['hash_dec_signed'] = 1941280070,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2488569781,
+					['hash_dec_signed'] = -1806397515,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2637560292,
+					['hash_dec_signed'] = -1657407004,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1123955257,
+					['hash_dec_signed'] = 1123955257,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3093558189,
+					['hash_dec_signed'] = -1201409107,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_018_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[19] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4175818022,
+					['hash_dec_signed'] = -119149274,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 655117220,
+					['hash_dec_signed'] = 655117220,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1105720530,
+					['hash_dec_signed'] = 1105720530,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 70377968,
+					['hash_dec_signed'] = 70377968,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1585929500,
+					['hash_dec_signed'] = 1585929500,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1961611157,
+					['hash_dec_signed'] = 1961611157,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1698224187,
+					['hash_dec_signed'] = 1698224187,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1662103488,
+					['hash_dec_signed'] = 1662103488,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2586621416,
+					['hash_dec_signed'] = -1708345880,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3420941775,
+					['hash_dec_signed'] = -874025521,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3595703022,
+					['hash_dec_signed'] = -699264274,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1152706980,
+					['hash_dec_signed'] = 1152706980,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3447144270,
+					['hash_dec_signed'] = -847823026,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1980454529,
+					['hash_dec_signed'] = 1980454529,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4193808436,
+					['hash_dec_signed'] = -101158860,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3685924309,
+					['hash_dec_signed'] = -609042987,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4134734135,
+					['hash_dec_signed'] = -160233161,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_019_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[20] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2249755552,
+					['hash_dec_signed'] = -2045211744,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1109815442,
+					['hash_dec_signed'] = 1109815442,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 34937916,
+					['hash_dec_signed'] = 34937916,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4277725110,
+					['hash_dec_signed'] = -17242186,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 866213025,
+					['hash_dec_signed'] = 866213025,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4200975492,
+					['hash_dec_signed'] = -93991804,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 96809980,
+					['hash_dec_signed'] = 96809980,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 998378570,
+					['hash_dec_signed'] = 998378570,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1679131103,
+					['hash_dec_signed'] = 1679131103,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1127266435,
+					['hash_dec_signed'] = 1127266435,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1810794494,
+					['hash_dec_signed'] = 1810794494,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2075366895,
+					['hash_dec_signed'] = 2075366895,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3888121732,
+					['hash_dec_signed'] = -406845564,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2116241565,
+					['hash_dec_signed'] = 2116241565,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3494639591,
+					['hash_dec_signed'] = -800327705,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 846060781,
+					['hash_dec_signed'] = 846060781,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1734918270,
+					['hash_dec_signed'] = 1734918270,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_020_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[21] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1917811014,
+					['hash_dec_signed'] = 1917811014,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2637249862,
+					['hash_dec_signed'] = -1657717434,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1223020622,
+					['hash_dec_signed'] = 1223020622,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1820746414,
+					['hash_dec_signed'] = 1820746414,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3213976733,
+					['hash_dec_signed'] = -1080990563,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2691657480,
+					['hash_dec_signed'] = -1603309816,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2677483973,
+					['hash_dec_signed'] = -1617483323,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4129775678,
+					['hash_dec_signed'] = -165191618,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 271839352,
+					['hash_dec_signed'] = 271839352,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2375863365,
+					['hash_dec_signed'] = -1919103931,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2946550620,
+					['hash_dec_signed'] = -1348416676,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 866107234,
+					['hash_dec_signed'] = 866107234,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1648963249,
+					['hash_dec_signed'] = 1648963249,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3007050894,
+					['hash_dec_signed'] = -1287916402,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1120419167,
+					['hash_dec_signed'] = 1120419167,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1610349905,
+					['hash_dec_signed'] = 1610349905,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3247337555,
+					['hash_dec_signed'] = -1047629741,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_021_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[22] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2174658263,
+					['hash_dec_signed'] = -2120309033,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2528847946,
+					['hash_dec_signed'] = -1766119350,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2530983547,
+					['hash_dec_signed'] = -1763983749,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 811599175,
+					['hash_dec_signed'] = 811599175,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 792017842,
+					['hash_dec_signed'] = 792017842,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2811431496,
+					['hash_dec_signed'] = -1483535800,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2331532415,
+					['hash_dec_signed'] = -1963434881,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 208985507,
+					['hash_dec_signed'] = 208985507,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2783431279,
+					['hash_dec_signed'] = -1511536017,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2299240178,
+					['hash_dec_signed'] = -1995727118,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 294577146,
+					['hash_dec_signed'] = 294577146,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3606631315,
+					['hash_dec_signed'] = -688335981,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 999391329,
+					['hash_dec_signed'] = 999391329,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1186911133,
+					['hash_dec_signed'] = 1186911133,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2442332024,
+					['hash_dec_signed'] = -1852635272,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2431155848,
+					['hash_dec_signed'] = -1863811448,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3767728745,
+					['hash_dec_signed'] = -527238551,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_022_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[23] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 915512969,
+					['hash_dec_signed'] = 915512969,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1497930606,
+					['hash_dec_signed'] = 1497930606,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2018241175,
+					['hash_dec_signed'] = 2018241175,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2135308921,
+					['hash_dec_signed'] = 2135308921,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2092471499,
+					['hash_dec_signed'] = 2092471499,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3653192448,
+					['hash_dec_signed'] = -641774848,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 702099763,
+					['hash_dec_signed'] = 702099763,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3746720680,
+					['hash_dec_signed'] = -548246616,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2535479035,
+					['hash_dec_signed'] = -1759488261,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4182356180,
+					['hash_dec_signed'] = -112611116,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2479200979,
+					['hash_dec_signed'] = -1815766317,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2579924776,
+					['hash_dec_signed'] = -1715042520,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4018770401,
+					['hash_dec_signed'] = -276196895,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 725162398,
+					['hash_dec_signed'] = 725162398,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2662120247,
+					['hash_dec_signed'] = -1632847049,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3956954027,
+					['hash_dec_signed'] = -338013269,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 249454280,
+					['hash_dec_signed'] = 249454280,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_023_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[24] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 927821405,
+					['hash_dec_signed'] = 927821405,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4281102004,
+					['hash_dec_signed'] = -13865292,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 952357808,
+					['hash_dec_signed'] = 952357808,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3660636070,
+					['hash_dec_signed'] = -634331226,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1794220146,
+					['hash_dec_signed'] = 1794220146,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1009655517,
+					['hash_dec_signed'] = 1009655517,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 751446730,
+					['hash_dec_signed'] = 751446730,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1814213670,
+					['hash_dec_signed'] = 1814213670,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4255066946,
+					['hash_dec_signed'] = -39900350,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2391191108,
+					['hash_dec_signed'] = -1903776188,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4266921205,
+					['hash_dec_signed'] = -28046091,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1188702271,
+					['hash_dec_signed'] = 1188702271,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4257455498,
+					['hash_dec_signed'] = -37511798,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1134090621,
+					['hash_dec_signed'] = 1134090621,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3690584151,
+					['hash_dec_signed'] = -604383145,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1072744937,
+					['hash_dec_signed'] = 1072744937,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 51802513,
+					['hash_dec_signed'] = 51802513,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_024_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[25] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3446625095,
+					['hash_dec_signed'] = -848342201,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 546401976,
+					['hash_dec_signed'] = 546401976,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1507733864,
+					['hash_dec_signed'] = 1507733864,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2094733404,
+					['hash_dec_signed'] = 2094733404,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1741755508,
+					['hash_dec_signed'] = 1741755508,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 246348133,
+					['hash_dec_signed'] = 246348133,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1436936800,
+					['hash_dec_signed'] = 1436936800,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2456670194,
+					['hash_dec_signed'] = -1838297102,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2626599026,
+					['hash_dec_signed'] = -1668368270,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3632881362,
+					['hash_dec_signed'] = -662085934,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 494012117,
+					['hash_dec_signed'] = 494012117,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3686371722,
+					['hash_dec_signed'] = -608595574,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1237586132,
+					['hash_dec_signed'] = 1237586132,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 907876401,
+					['hash_dec_signed'] = 907876401,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2682047773,
+					['hash_dec_signed'] = -1612919523,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2807589358,
+					['hash_dec_signed'] = -1487377938,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4011042910,
+					['hash_dec_signed'] = -283924386,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_025_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[26] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3991177694,
+					['hash_dec_signed'] = -303789602,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2124870560,
+					['hash_dec_signed'] = 2124870560,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3949837998,
+					['hash_dec_signed'] = -345129298,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 967738392,
+					['hash_dec_signed'] = 967738392,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3780503488,
+					['hash_dec_signed'] = -514463808,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1169356545,
+					['hash_dec_signed'] = 1169356545,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 315772104,
+					['hash_dec_signed'] = 315772104,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3480331822,
+					['hash_dec_signed'] = -814635474,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3972030555,
+					['hash_dec_signed'] = -322936741,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4038811387,
+					['hash_dec_signed'] = -256155909,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2636386085,
+					['hash_dec_signed'] = -1658581211,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1159263025,
+					['hash_dec_signed'] = 1159263025,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2570407912,
+					['hash_dec_signed'] = -1724559384,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2128107338,
+					['hash_dec_signed'] = 2128107338,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4019815510,
+					['hash_dec_signed'] = -275151786,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4283228006,
+					['hash_dec_signed'] = -11739290,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2509813275,
+					['hash_dec_signed'] = -1785154021,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_026_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[27] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 88214985,
+					['hash_dec_signed'] = 88214985,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 590577033,
+					['hash_dec_signed'] = 590577033,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2075765705,
+					['hash_dec_signed'] = 2075765705,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3365200421,
+					['hash_dec_signed'] = -929766875,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3724508430,
+					['hash_dec_signed'] = -570458866,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2367376075,
+					['hash_dec_signed'] = -1927591221,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1248819316,
+					['hash_dec_signed'] = 1248819316,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1509839034,
+					['hash_dec_signed'] = 1509839034,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2821192214,
+					['hash_dec_signed'] = -1473775082,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 429089805,
+					['hash_dec_signed'] = 429089805,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2390160229,
+					['hash_dec_signed'] = -1904807067,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 483498115,
+					['hash_dec_signed'] = 483498115,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1170424579,
+					['hash_dec_signed'] = 1170424579,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3778856154,
+					['hash_dec_signed'] = -516111142,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1778297235,
+					['hash_dec_signed'] = 1778297235,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3745656829,
+					['hash_dec_signed'] = -549310467,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3786806939,
+					['hash_dec_signed'] = -508160357,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_027_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[28] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2143613419,
+					['hash_dec_signed'] = 2143613419,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2325782784,
+					['hash_dec_signed'] = -1969184512,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1818504000,
+					['hash_dec_signed'] = 1818504000,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 929414529,
+					['hash_dec_signed'] = 929414529,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1147582722,
+					['hash_dec_signed'] = 1147582722,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2409141307,
+					['hash_dec_signed'] = -1885825989,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2527083790,
+					['hash_dec_signed'] = -1767883506,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3632937178,
+					['hash_dec_signed'] = -662030118,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3893697401,
+					['hash_dec_signed'] = -401269895,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2710980957,
+					['hash_dec_signed'] = -1583986339,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3813614526,
+					['hash_dec_signed'] = -481352770,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1492880698,
+					['hash_dec_signed'] = 1492880698,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 74975426,
+					['hash_dec_signed'] = 74975426,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3003374304,
+					['hash_dec_signed'] = -1291592992,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2016900903,
+					['hash_dec_signed'] = 2016900903,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2897944357,
+					['hash_dec_signed'] = -1397022939,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2789280932,
+					['hash_dec_signed'] = -1505686364,
+					['hashname'] = 'CLOTHING_ITEM_F_HAIR_028_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[18] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 443322889,
+					['hash_dec_signed'] = 443322889,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[29] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 220739303,
+					['hash_dec_signed'] = 220739303,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 399163876,
+					['hash_dec_signed'] = 399163876,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 583643232,
+					['hash_dec_signed'] = 583643232,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 725774568,
+					['hash_dec_signed'] = 725774568,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 897268394,
+					['hash_dec_signed'] = 897268394,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1974164344,
+					['hash_dec_signed'] = 1974164344,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2239733500,
+					['hash_dec_signed'] = -2055233796,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2742847919,
+					['hash_dec_signed'] = -1552119377,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2804631008,
+					['hash_dec_signed'] = -1490336288,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2981680891,
+					['hash_dec_signed'] = -1313286405,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3069021694,
+					['hash_dec_signed'] = -1225945602,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3242080706,
+					['hash_dec_signed'] = -1052886590,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3349445404,
+					['hash_dec_signed'] = -945521892,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3381770942,
+					['hash_dec_signed'] = -913196354,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3428555671,
+					['hash_dec_signed'] = -866411625,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3557584251,
+					['hash_dec_signed'] = -737383045,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3607322698,
+					['hash_dec_signed'] = -687644598,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[30] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 133371048,
+					['hash_dec_signed'] = 133371048,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 144619495,
+					['hash_dec_signed'] = 144619495,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 724255336,
+					['hash_dec_signed'] = 724255336,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 953295761,
+					['hash_dec_signed'] = 953295761,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1031019028,
+					['hash_dec_signed'] = 1031019028,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1181658187,
+					['hash_dec_signed'] = 1181658187,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1322599261,
+					['hash_dec_signed'] = 1322599261,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2074136664,
+					['hash_dec_signed'] = 2074136664,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2088842941,
+					['hash_dec_signed'] = 2088842941,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2386771057,
+					['hash_dec_signed'] = -1908196239,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2713043204,
+					['hash_dec_signed'] = -1581924092,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3210901981,
+					['hash_dec_signed'] = -1084065315,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3417894291,
+					['hash_dec_signed'] = -877073005,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3474028136,
+					['hash_dec_signed'] = -820939160,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3733473558,
+					['hash_dec_signed'] = -561493738,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3838151752,
+					['hash_dec_signed'] = -456815544,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3935553687,
+					['hash_dec_signed'] = -359413609,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[31] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 202244428,
+					['hash_dec_signed'] = 202244428,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 548874910,
+					['hash_dec_signed'] = 548874910,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1112305096,
+					['hash_dec_signed'] = 1112305096,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2025151129,
+					['hash_dec_signed'] = 2025151129,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			},
+			[32] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 0x2A640582,
+					['hash_dec_signed'] = 711198082,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 0x71BF8D56,
+					['hash_dec_signed'] = 1908378966,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 0x8F4328D0,
+					['hash_dec_signed'] = -1891424048,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 0xB7772FA8,
+					['hash_dec_signed'] = -1216925784,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'female'
+				},
+			}
+		}
+	},
+	['male'] = {
+		['beard'] = {
+			[1] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 560477017,
+					['hash_dec_signed'] = 560477017,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3359999566,
+					['hash_dec_signed'] = -934967730,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3811269149,
+					['hash_dec_signed'] = -483698147,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1700911990,
+					['hash_dec_signed'] = 1700911990,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1953208774,
+					['hash_dec_signed'] = 1953208774,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3428413098,
+					['hash_dec_signed'] = -866554198,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3128266259,
+					['hash_dec_signed'] = -1166701037,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 122428071,
+					['hash_dec_signed'] = 122428071,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3926915906,
+					['hash_dec_signed'] = -368051390,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3468384252,
+					['hash_dec_signed'] = -826583044,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 768038038,
+					['hash_dec_signed'] = 768038038,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 351936442,
+					['hash_dec_signed'] = 351936442,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2834932461,
+					['hash_dec_signed'] = -1460034835,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1522736310,
+					['hash_dec_signed'] = 1522736310,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2196041061,
+					['hash_dec_signed'] = -2098926235,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2841222333,
+					['hash_dec_signed'] = -1453744963,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2484842446,
+					['hash_dec_signed'] = -1810124850,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_001_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4127777233,
+					['hash_dec_signed'] = -167190063,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[2] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1906774516,
+					['hash_dec_signed'] = 1906774516,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3891950391,
+					['hash_dec_signed'] = -403016905,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1517615086,
+					['hash_dec_signed'] = 1517615086,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 529788430,
+					['hash_dec_signed'] = 529788430,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2927222219,
+					['hash_dec_signed'] = -1367745077,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2181192407,
+					['hash_dec_signed'] = -2113774889,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3633324851,
+					['hash_dec_signed'] = -661642445,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1269387091,
+					['hash_dec_signed'] = 1269387091,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1692876447,
+					['hash_dec_signed'] = 1692876447,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 661022885,
+					['hash_dec_signed'] = 661022885,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2654365761,
+					['hash_dec_signed'] = -1640601535,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1561687115,
+					['hash_dec_signed'] = 1561687115,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 773929310,
+					['hash_dec_signed'] = 773929310,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1092082138,
+					['hash_dec_signed'] = 1092082138,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 381599086,
+					['hash_dec_signed'] = 381599086,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4252816540,
+					['hash_dec_signed'] = -42150756,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1647585511,
+					['hash_dec_signed'] = 1647585511,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_002_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[3] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3965585130,
+					['hash_dec_signed'] = -329382166,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3261987659,
+					['hash_dec_signed'] = -1032979637,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4251665592,
+					['hash_dec_signed'] = -43301704,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1114869792,
+					['hash_dec_signed'] = 1114869792,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 962097997,
+					['hash_dec_signed'] = 962097997,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 839868052,
+					['hash_dec_signed'] = 839868052,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2592094004,
+					['hash_dec_signed'] = -1702873292,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1889659997,
+					['hash_dec_signed'] = 1889659997,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3101964980,
+					['hash_dec_signed'] = -1193002316,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3499245083,
+					['hash_dec_signed'] = -795722213,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3852769926,
+					['hash_dec_signed'] = -442197370,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3200116226,
+					['hash_dec_signed'] = -1094851070,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2224626300,
+					['hash_dec_signed'] = -2070340996,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4209486082,
+					['hash_dec_signed'] = -85481214,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2673606804,
+					['hash_dec_signed'] = -1621360492,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4102053214,
+					['hash_dec_signed'] = -192914082,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 611832531,
+					['hash_dec_signed'] = 611832531,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_003_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[4] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 306678665,
+					['hash_dec_signed'] = 306678665,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1262135006,
+					['hash_dec_signed'] = 1262135006,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1346672098,
+					['hash_dec_signed'] = 1346672098,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1278497410,
+					['hash_dec_signed'] = 1278497410,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3717390630,
+					['hash_dec_signed'] = -577576666,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3295253150,
+					['hash_dec_signed'] = -999714146,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3016142633,
+					['hash_dec_signed'] = -1278824663,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 784428444,
+					['hash_dec_signed'] = 784428444,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 166579674,
+					['hash_dec_signed'] = 166579674,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1505085490,
+					['hash_dec_signed'] = 1505085490,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1883341592,
+					['hash_dec_signed'] = 1883341592,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2110468749,
+					['hash_dec_signed'] = 2110468749,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2675055356,
+					['hash_dec_signed'] = -1619911940,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2031466514,
+					['hash_dec_signed'] = 2031466514,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1192139082,
+					['hash_dec_signed'] = 1192139082,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2428864485,
+					['hash_dec_signed'] = -1866102811,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1715749200,
+					['hash_dec_signed'] = 1715749200,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_004_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[5] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3593465254,
+					['hash_dec_signed'] = -701502042,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1073719212,
+					['hash_dec_signed'] = 1073719212,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 59227358,
+					['hash_dec_signed'] = 59227358,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2377311071,
+					['hash_dec_signed'] = -1917656225,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3136919646,
+					['hash_dec_signed'] = -1158047650,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1784730331,
+					['hash_dec_signed'] = 1784730331,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2869194922,
+					['hash_dec_signed'] = -1425772374,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3994876446,
+					['hash_dec_signed'] = -300090850,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 252768736,
+					['hash_dec_signed'] = 252768736,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1422368367,
+					['hash_dec_signed'] = 1422368367,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4177888721,
+					['hash_dec_signed'] = -117078575,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2326397606,
+					['hash_dec_signed'] = -1968569690,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3170246895,
+					['hash_dec_signed'] = -1124720401,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2979982612,
+					['hash_dec_signed'] = -1314984684,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1508626347,
+					['hash_dec_signed'] = 1508626347,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4002065779,
+					['hash_dec_signed'] = -292901517,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3080466848,
+					['hash_dec_signed'] = -1214500448,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_005_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[6] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3805554892,
+					['hash_dec_signed'] = -489412404,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 226841406,
+					['hash_dec_signed'] = 226841406,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2458131705,
+					['hash_dec_signed'] = -1836835591,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2165856356,
+					['hash_dec_signed'] = -2129110940,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1783629149,
+					['hash_dec_signed'] = 1783629149,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2347083130,
+					['hash_dec_signed'] = -1947884166,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3963253620,
+					['hash_dec_signed'] = -331713676,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3665597818,
+					['hash_dec_signed'] = -629369478,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1375791587,
+					['hash_dec_signed'] = 1375791587,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 830243454,
+					['hash_dec_signed'] = 830243454,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1672202441,
+					['hash_dec_signed'] = 1672202441,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1900893047,
+					['hash_dec_signed'] = 1900893047,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1807816867,
+					['hash_dec_signed'] = 1807816867,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3720413870,
+					['hash_dec_signed'] = -574553426,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 649961113,
+					['hash_dec_signed'] = 649961113,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 506016508,
+					['hash_dec_signed'] = 506016508,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2972528156,
+					['hash_dec_signed'] = -1322439140,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_006_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[7] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 354937489,
+					['hash_dec_signed'] = 354937489,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2031577909,
+					['hash_dec_signed'] = 2031577909,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1658715876,
+					['hash_dec_signed'] = 1658715876,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2705244413,
+					['hash_dec_signed'] = -1589722883,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 298392309,
+					['hash_dec_signed'] = 298392309,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 185164474,
+					['hash_dec_signed'] = 185164474,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1264771549,
+					['hash_dec_signed'] = 1264771549,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 766015793,
+					['hash_dec_signed'] = 766015793,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1855989868,
+					['hash_dec_signed'] = 1855989868,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2679509709,
+					['hash_dec_signed'] = -1615457587,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1743934292,
+					['hash_dec_signed'] = 1743934292,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3388554110,
+					['hash_dec_signed'] = -906413186,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1881866345,
+					['hash_dec_signed'] = 1881866345,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 481122513,
+					['hash_dec_signed'] = 481122513,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 75152474,
+					['hash_dec_signed'] = 75152474,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2316362411,
+					['hash_dec_signed'] = -1978604885,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2253995546,
+					['hash_dec_signed'] = -2040971750,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_007_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[8] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1597397871,
+					['hash_dec_signed'] = 1597397871,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2210118077,
+					['hash_dec_signed'] = -2084849219,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 990976242,
+					['hash_dec_signed'] = 990976242,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1491762223,
+					['hash_dec_signed'] = 1491762223,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4094840815,
+					['hash_dec_signed'] = -200126481,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1807775801,
+					['hash_dec_signed'] = 1807775801,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3494122446,
+					['hash_dec_signed'] = -800844850,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1797835665,
+					['hash_dec_signed'] = 1797835665,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1072039547,
+					['hash_dec_signed'] = 1072039547,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 683934875,
+					['hash_dec_signed'] = 683934875,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3001136381,
+					['hash_dec_signed'] = -1293830915,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1623302616,
+					['hash_dec_signed'] = 1623302616,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 145804206,
+					['hash_dec_signed'] = 145804206,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2838736201,
+					['hash_dec_signed'] = -1456231095,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 424212880,
+					['hash_dec_signed'] = 424212880,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1620228718,
+					['hash_dec_signed'] = 1620228718,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3426387291,
+					['hash_dec_signed'] = -868580005,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_008_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[9] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1882197063,
+					['hash_dec_signed'] = 1882197063,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4064296031,
+					['hash_dec_signed'] = -230671265,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 785798480,
+					['hash_dec_signed'] = 785798480,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4234219349,
+					['hash_dec_signed'] = -60747947,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3799450529,
+					['hash_dec_signed'] = -495516767,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1257638385,
+					['hash_dec_signed'] = 1257638385,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1713580799,
+					['hash_dec_signed'] = 1713580799,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3783314784,
+					['hash_dec_signed'] = -511652512,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1244870786,
+					['hash_dec_signed'] = 1244870786,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4110243018,
+					['hash_dec_signed'] = -184724278,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 841976497,
+					['hash_dec_signed'] = 841976497,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 180350727,
+					['hash_dec_signed'] = 180350727,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4179638410,
+					['hash_dec_signed'] = -115328886,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4051416117,
+					['hash_dec_signed'] = -243551179,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4187014157,
+					['hash_dec_signed'] = -107953139,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1076604375,
+					['hash_dec_signed'] = 1076604375,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1536172717,
+					['hash_dec_signed'] = 1536172717,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_009_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1744685570,
+					['hash_dec_signed'] = 1744685570,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[10] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 934537342,
+					['hash_dec_signed'] = 934537342,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1127522151,
+					['hash_dec_signed'] = 1127522151,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2670447343,
+					['hash_dec_signed'] = -1624519953,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2056621230,
+					['hash_dec_signed'] = 2056621230,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1402999799,
+					['hash_dec_signed'] = 1402999799,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 757034744,
+					['hash_dec_signed'] = 757034744,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 631072807,
+					['hash_dec_signed'] = 631072807,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2143523902,
+					['hash_dec_signed'] = 2143523902,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4031164574,
+					['hash_dec_signed'] = -263802722,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2414746645,
+					['hash_dec_signed'] = -1880220651,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3414927490,
+					['hash_dec_signed'] = -880039806,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 822923592,
+					['hash_dec_signed'] = 822923592,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2858182524,
+					['hash_dec_signed'] = -1436784772,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3462712427,
+					['hash_dec_signed'] = -832254869,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3176954766,
+					['hash_dec_signed'] = -1118012530,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1125203251,
+					['hash_dec_signed'] = 1125203251,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3002038257,
+					['hash_dec_signed'] = -1292929039,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_010_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4279620277,
+					['hash_dec_signed'] = -15347019,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[11] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1658129915,
+					['hash_dec_signed'] = 1658129915,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3606833227,
+					['hash_dec_signed'] = -688134069,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 111710205,
+					['hash_dec_signed'] = 111710205,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3757979606,
+					['hash_dec_signed'] = -536987690,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3706499520,
+					['hash_dec_signed'] = -588467776,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 516169719,
+					['hash_dec_signed'] = 516169719,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1818061280,
+					['hash_dec_signed'] = 1818061280,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1560460654,
+					['hash_dec_signed'] = 1560460654,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 549062696,
+					['hash_dec_signed'] = 549062696,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1210149633,
+					['hash_dec_signed'] = 1210149633,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2658301552,
+					['hash_dec_signed'] = -1636665744,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3568848985,
+					['hash_dec_signed'] = -726118311,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2268535099,
+					['hash_dec_signed'] = -2026432197,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3173658289,
+					['hash_dec_signed'] = -1121309007,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3928420048,
+					['hash_dec_signed'] = -366547248,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2697665153,
+					['hash_dec_signed'] = -1597302143,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1896236580,
+					['hash_dec_signed'] = 1896236580,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_011_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[12] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1437370193,
+					['hash_dec_signed'] = 1437370193,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2564197849,
+					['hash_dec_signed'] = -1730769447,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1036166436,
+					['hash_dec_signed'] = 1036166436,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1105419118,
+					['hash_dec_signed'] = 1105419118,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 307184935,
+					['hash_dec_signed'] = 307184935,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2816141621,
+					['hash_dec_signed'] = -1478825675,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3848157593,
+					['hash_dec_signed'] = -446809703,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1666623013,
+					['hash_dec_signed'] = 1666623013,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1206933050,
+					['hash_dec_signed'] = 1206933050,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1372322083,
+					['hash_dec_signed'] = 1372322083,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1457766250,
+					['hash_dec_signed'] = 1457766250,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1451003681,
+					['hash_dec_signed'] = 1451003681,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1376969807,
+					['hash_dec_signed'] = 1376969807,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1213264145,
+					['hash_dec_signed'] = 1213264145,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4243253661,
+					['hash_dec_signed'] = -51713635,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 74902531,
+					['hash_dec_signed'] = 74902531,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 39295965,
+					['hash_dec_signed'] = 39295965,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_012_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[13] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3169600415,
+					['hash_dec_signed'] = -1125366881,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1063184222,
+					['hash_dec_signed'] = 1063184222,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 382614413,
+					['hash_dec_signed'] = 382614413,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3359587060,
+					['hash_dec_signed'] = -935380236,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1239485608,
+					['hash_dec_signed'] = 1239485608,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1163598653,
+					['hash_dec_signed'] = 1163598653,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1389714514,
+					['hash_dec_signed'] = 1389714514,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2587879296,
+					['hash_dec_signed'] = -1707088000,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 605652010,
+					['hash_dec_signed'] = 605652010,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3750364151,
+					['hash_dec_signed'] = -544603145,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1971724686,
+					['hash_dec_signed'] = 1971724686,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 502538388,
+					['hash_dec_signed'] = 502538388,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3750146482,
+					['hash_dec_signed'] = -544820814,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1717239876,
+					['hash_dec_signed'] = 1717239876,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2663513395,
+					['hash_dec_signed'] = -1631453901,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 146025810,
+					['hash_dec_signed'] = 146025810,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2706920252,
+					['hash_dec_signed'] = -1588047044,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_013_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[14] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2836117189,
+					['hash_dec_signed'] = -1458850107,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2549723902,
+					['hash_dec_signed'] = -1745243394,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3187802383,
+					['hash_dec_signed'] = -1107164913,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3538861559,
+					['hash_dec_signed'] = -756105737,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1204379617,
+					['hash_dec_signed'] = 1204379617,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2929866760,
+					['hash_dec_signed'] = -1365100536,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 508353135,
+					['hash_dec_signed'] = 508353135,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1664964724,
+					['hash_dec_signed'] = 1664964724,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1311851556,
+					['hash_dec_signed'] = 1311851556,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2639004079,
+					['hash_dec_signed'] = -1655963217,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1620485665,
+					['hash_dec_signed'] = 1620485665,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4183051519,
+					['hash_dec_signed'] = -111915777,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2235804659,
+					['hash_dec_signed'] = -2059162637,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 323985567,
+					['hash_dec_signed'] = 323985567,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 133965099,
+					['hash_dec_signed'] = 133965099,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1082664383,
+					['hash_dec_signed'] = 1082664383,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 95718510,
+					['hash_dec_signed'] = 95718510,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_014_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[15] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3270933002,
+					['hash_dec_signed'] = -1024034294,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3106733659,
+					['hash_dec_signed'] = -1188233637,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2339538374,
+					['hash_dec_signed'] = -1955428922,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2869759893,
+					['hash_dec_signed'] = -1425207403,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1804112853,
+					['hash_dec_signed'] = 1804112853,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3372798554,
+					['hash_dec_signed'] = -922168742,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2209754912,
+					['hash_dec_signed'] = -2085212384,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4076216113,
+					['hash_dec_signed'] = -218751183,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 601768357,
+					['hash_dec_signed'] = 601768357,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1727197799,
+					['hash_dec_signed'] = 1727197799,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3455182175,
+					['hash_dec_signed'] = -839785121,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3491375629,
+					['hash_dec_signed'] = -803591667,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1625991163,
+					['hash_dec_signed'] = 1625991163,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1706701994,
+					['hash_dec_signed'] = 1706701994,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1270498360,
+					['hash_dec_signed'] = 1270498360,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 319152566,
+					['hash_dec_signed'] = 319152566,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1820377312,
+					['hash_dec_signed'] = 1820377312,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_015_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[16] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 248711205,
+					['hash_dec_signed'] = 248711205,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2937424526,
+					['hash_dec_signed'] = -1357542770,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2771489520,
+					['hash_dec_signed'] = -1523477776,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4029336581,
+					['hash_dec_signed'] = -265630715,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2696207373,
+					['hash_dec_signed'] = -1598759923,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2004750666,
+					['hash_dec_signed'] = 2004750666,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4088282214,
+					['hash_dec_signed'] = -206685082,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3967340697,
+					['hash_dec_signed'] = -327626599,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2115010028,
+					['hash_dec_signed'] = 2115010028,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1119270192,
+					['hash_dec_signed'] = 1119270192,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 683891516,
+					['hash_dec_signed'] = 683891516,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 145201052,
+					['hash_dec_signed'] = 145201052,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 766301466,
+					['hash_dec_signed'] = 766301466,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2543734778,
+					['hash_dec_signed'] = -1751232518,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2178256954,
+					['hash_dec_signed'] = -2116710342,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1121209784,
+					['hash_dec_signed'] = 1121209784,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1676545681,
+					['hash_dec_signed'] = 1676545681,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_016_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[17] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2415588384,
+					['hash_dec_signed'] = -1879378912,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 555155903,
+					['hash_dec_signed'] = 555155903,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 282054283,
+					['hash_dec_signed'] = 282054283,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3010498713,
+					['hash_dec_signed'] = -1284468583,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1071274056,
+					['hash_dec_signed'] = 1071274056,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1885907986,
+					['hash_dec_signed'] = 1885907986,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2169749075,
+					['hash_dec_signed'] = -2125218221,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 164485044,
+					['hash_dec_signed'] = 164485044,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2973239026,
+					['hash_dec_signed'] = -1321728270,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2397940937,
+					['hash_dec_signed'] = -1897026359,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3805805594,
+					['hash_dec_signed'] = -489161702,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4133352301,
+					['hash_dec_signed'] = -161614995,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1232390969,
+					['hash_dec_signed'] = 1232390969,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1496508503,
+					['hash_dec_signed'] = 1496508503,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3670735525,
+					['hash_dec_signed'] = -624231771,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2054997725,
+					['hash_dec_signed'] = 2054997725,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2148944406,
+					['hash_dec_signed'] = -2146022890,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_017_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[18] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 390637164,
+					['hash_dec_signed'] = 390637164,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1858184912,
+					['hash_dec_signed'] = 1858184912,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3521221739,
+					['hash_dec_signed'] = -773745557,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3354484471,
+					['hash_dec_signed'] = -940482825,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4078914253,
+					['hash_dec_signed'] = -216053043,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1920767020,
+					['hash_dec_signed'] = 1920767020,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2104391593,
+					['hash_dec_signed'] = 2104391593,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3223635078,
+					['hash_dec_signed'] = -1071332218,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1802175605,
+					['hash_dec_signed'] = 1802175605,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1858638465,
+					['hash_dec_signed'] = 1858638465,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2037363766,
+					['hash_dec_signed'] = 2037363766,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4239242526,
+					['hash_dec_signed'] = -55724770,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 231928634,
+					['hash_dec_signed'] = 231928634,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3252081425,
+					['hash_dec_signed'] = -1042885871,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 484622924,
+					['hash_dec_signed'] = 484622924,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1050007297,
+					['hash_dec_signed'] = 1050007297,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 261793413,
+					['hash_dec_signed'] = 261793413,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_018_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[19] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3202209652,
+					['hash_dec_signed'] = -1092757644,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1351177428,
+					['hash_dec_signed'] = 1351177428,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1807543115,
+					['hash_dec_signed'] = 1807543115,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1807494016,
+					['hash_dec_signed'] = 1807494016,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4197281720,
+					['hash_dec_signed'] = -97685576,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3364810881,
+					['hash_dec_signed'] = -930156415,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1957241420,
+					['hash_dec_signed'] = 1957241420,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3891804603,
+					['hash_dec_signed'] = -403162693,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2126455682,
+					['hash_dec_signed'] = 2126455682,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3130258751,
+					['hash_dec_signed'] = -1164708545,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2276918031,
+					['hash_dec_signed'] = -2018049265,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1415120973,
+					['hash_dec_signed'] = 1415120973,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 175443526,
+					['hash_dec_signed'] = 175443526,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2077475408,
+					['hash_dec_signed'] = 2077475408,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1552798668,
+					['hash_dec_signed'] = 1552798668,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2860810906,
+					['hash_dec_signed'] = -1434156390,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 199121926,
+					['hash_dec_signed'] = 199121926,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_019_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[20] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3678086192,
+					['hash_dec_signed'] = -616881104,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1529291189,
+					['hash_dec_signed'] = 1529291189,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 111379000,
+					['hash_dec_signed'] = 111379000,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3163913471,
+					['hash_dec_signed'] = -1131053825,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2896881433,
+					['hash_dec_signed'] = -1398085863,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1387443021,
+					['hash_dec_signed'] = 1387443021,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3563599103,
+					['hash_dec_signed'] = -731368193,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 983283548,
+					['hash_dec_signed'] = 983283548,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 587465329,
+					['hash_dec_signed'] = 587465329,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 949651033,
+					['hash_dec_signed'] = 949651033,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2084264417,
+					['hash_dec_signed'] = 2084264417,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 898572524,
+					['hash_dec_signed'] = 898572524,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3263282150,
+					['hash_dec_signed'] = -1031685146,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1864790483,
+					['hash_dec_signed'] = 1864790483,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2042541768,
+					['hash_dec_signed'] = 2042541768,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2197298280,
+					['hash_dec_signed'] = -2097669016,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3492210719,
+					['hash_dec_signed'] = -802756577,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_020_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[21] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4214953211,
+					['hash_dec_signed'] = -80014085,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2673590163,
+					['hash_dec_signed'] = -1621377133,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3202083669,
+					['hash_dec_signed'] = -1092883627,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1718088001,
+					['hash_dec_signed'] = 1718088001,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2723814342,
+					['hash_dec_signed'] = -1571152954,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3855680805,
+					['hash_dec_signed'] = -439286491,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 19363891,
+					['hash_dec_signed'] = 19363891,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3495936372,
+					['hash_dec_signed'] = -799030924,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3515089297,
+					['hash_dec_signed'] = -779877999,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 96189939,
+					['hash_dec_signed'] = 96189939,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2743289969,
+					['hash_dec_signed'] = -1551677327,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4013069152,
+					['hash_dec_signed'] = -281898144,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 638112146,
+					['hash_dec_signed'] = 638112146,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 846185989,
+					['hash_dec_signed'] = 846185989,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1998279575,
+					['hash_dec_signed'] = 1998279575,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2905047290,
+					['hash_dec_signed'] = -1389920006,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 851618488,
+					['hash_dec_signed'] = 851618488,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_021_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[22] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3720555038,
+					['hash_dec_signed'] = -574412258,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4054521870,
+					['hash_dec_signed'] = -240445426,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2733871421,
+					['hash_dec_signed'] = -1561095875,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1037532367,
+					['hash_dec_signed'] = 1037532367,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3454329345,
+					['hash_dec_signed'] = -840637951,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3228745165,
+					['hash_dec_signed'] = -1066222131,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2016318535,
+					['hash_dec_signed'] = 2016318535,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 518502517,
+					['hash_dec_signed'] = 518502517,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2089978915,
+					['hash_dec_signed'] = 2089978915,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4006182275,
+					['hash_dec_signed'] = -288785021,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3678542354,
+					['hash_dec_signed'] = -616424942,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4119072356,
+					['hash_dec_signed'] = -175894940,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1659065808,
+					['hash_dec_signed'] = 1659065808,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1418693294,
+					['hash_dec_signed'] = 1418693294,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1676777041,
+					['hash_dec_signed'] = 1676777041,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2891677343,
+					['hash_dec_signed'] = -1403289953,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2941020767,
+					['hash_dec_signed'] = -1353946529,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_022_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[23] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3939138320,
+					['hash_dec_signed'] = -355828976,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4203626976,
+					['hash_dec_signed'] = -91340320,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 348235608,
+					['hash_dec_signed'] = 348235608,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 453986413,
+					['hash_dec_signed'] = 453986413,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1788167345,
+					['hash_dec_signed'] = 1788167345,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3280423972,
+					['hash_dec_signed'] = -1014543324,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2366243005,
+					['hash_dec_signed'] = -1928724291,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3788428150,
+					['hash_dec_signed'] = -506539146,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 603874579,
+					['hash_dec_signed'] = 603874579,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3745135171,
+					['hash_dec_signed'] = -549832125,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3274186849,
+					['hash_dec_signed'] = -1020780447,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 948242550,
+					['hash_dec_signed'] = 948242550,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2138943690,
+					['hash_dec_signed'] = 2138943690,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1086943796,
+					['hash_dec_signed'] = 1086943796,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2785726214,
+					['hash_dec_signed'] = -1509241082,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1703681656,
+					['hash_dec_signed'] = 1703681656,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3213796942,
+					['hash_dec_signed'] = -1081170354,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_023_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[24] = {
+				[1] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1400480499,
+					['hash_dec_signed'] = 1400480499,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 257598950,
+					['hash_dec_signed'] = 257598950,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 17656519,
+					['hash_dec_signed'] = 17656519,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4162676863,
+					['hash_dec_signed'] = -132290433,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1550139832,
+					['hash_dec_signed'] = 1550139832,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2431077655,
+					['hash_dec_signed'] = -1863889641,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 564751375,
+					['hash_dec_signed'] = 564751375,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 2240704400,
+					['hash_dec_signed'] = -2054262896,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 315685828,
+					['hash_dec_signed'] = 315685828,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 265519583,
+					['hash_dec_signed'] = 265519583,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 4036955195,
+					['hash_dec_signed'] = -258012101,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 917365001,
+					['hash_dec_signed'] = 917365001,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1094772655,
+					['hash_dec_signed'] = 1094772655,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3478843776,
+					['hash_dec_signed'] = -816123520,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 3918210966,
+					['hash_dec_signed'] = -376756330,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 272648835,
+					['hash_dec_signed'] = 272648835,
+					['hashname'] = 'CLOTHING_ITEM_M_BEARD_024_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1766639216,
+					['hash_dec_signed'] = 1766639216,
+					['hashname'] = 'CLOTHING_ITEM_M_NECKERCHIEF_550_TINT_024',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 4160842698,
+					['category_hash_dec_signed'] = -134124598,
+					['category_hashname'] = 'beard',
+					['hash'] = 1412973097,
+					['hash_dec_signed'] = 1412973097,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			}
+	
+		},
+		['hair'] = {
+			[1] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2112480140,
+					['hash_dec_signed'] = 2112480140,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2622916743,
+					['hash_dec_signed'] = -1672050553,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3924054474,
+					['hash_dec_signed'] = -370912822,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2874852206,
+					['hash_dec_signed'] = -1420115090,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1892421592,
+					['hash_dec_signed'] = 1892421592,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3013807717,
+					['hash_dec_signed'] = -1281159579,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2649688461,
+					['hash_dec_signed'] = -1645278835,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3620866996,
+					['hash_dec_signed'] = -674100300,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1850917355,
+					['hash_dec_signed'] = 1850917355,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3259815218,
+					['hash_dec_signed'] = -1035152078,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 470018738,
+					['hash_dec_signed'] = 470018738,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3501652525,
+					['hash_dec_signed'] = -793314771,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3319269342,
+					['hash_dec_signed'] = -975697954,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 879214843,
+					['hash_dec_signed'] = 879214843,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 942910621,
+					['hash_dec_signed'] = 942910621,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2063489192,
+					['hash_dec_signed'] = 2063489192,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 929997375,
+					['hash_dec_signed'] = 929997375,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_001_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3414739370,
+					['hash_dec_signed'] = -880227926,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[2] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1414303182,
+					['hash_dec_signed'] = 1414303182,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2670890105,
+					['hash_dec_signed'] = -1624077191,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4199650471,
+					['hash_dec_signed'] = -95316825,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1760777841,
+					['hash_dec_signed'] = 1760777841,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 257756162,
+					['hash_dec_signed'] = 257756162,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2690487796,
+					['hash_dec_signed'] = -1604479500,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3884146271,
+					['hash_dec_signed'] = -410821025,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1788889546,
+					['hash_dec_signed'] = 1788889546,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3829475470,
+					['hash_dec_signed'] = -465491826,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2869758343,
+					['hash_dec_signed'] = -1425208953,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 192216653,
+					['hash_dec_signed'] = 192216653,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1209776412,
+					['hash_dec_signed'] = 1209776412,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 731356029,
+					['hash_dec_signed'] = 731356029,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2213512467,
+					['hash_dec_signed'] = -2081454829,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1042027152,
+					['hash_dec_signed'] = 1042027152,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 68409628,
+					['hash_dec_signed'] = 68409628,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 680521583,
+					['hash_dec_signed'] = 680521583,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_002_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[3] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1529984470,
+					['hash_dec_signed'] = 1529984470,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 163973342,
+					['hash_dec_signed'] = 163973342,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1900264118,
+					['hash_dec_signed'] = 1900264118,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1242718228,
+					['hash_dec_signed'] = 1242718228,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 471104751,
+					['hash_dec_signed'] = 471104751,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2093241299,
+					['hash_dec_signed'] = 2093241299,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1226668975,
+					['hash_dec_signed'] = 1226668975,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3239999591,
+					['hash_dec_signed'] = -1054967705,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 664756881,
+					['hash_dec_signed'] = 664756881,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3098552333,
+					['hash_dec_signed'] = -1196414963,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3745183268,
+					['hash_dec_signed'] = -549784028,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3180563235,
+					['hash_dec_signed'] = -1114404061,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1998608299,
+					['hash_dec_signed'] = 1998608299,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2389598176,
+					['hash_dec_signed'] = -1905369120,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2169616634,
+					['hash_dec_signed'] = -2125350662,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1734235879,
+					['hash_dec_signed'] = 1734235879,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 675995216,
+					['hash_dec_signed'] = 675995216,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_003_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[4] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 96942958,
+					['hash_dec_signed'] = 96942958,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 39008355,
+					['hash_dec_signed'] = 39008355,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1165891494,
+					['hash_dec_signed'] = 1165891494,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1060376337,
+					['hash_dec_signed'] = 1060376337,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2767034692,
+					['hash_dec_signed'] = -1527932604,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2275703638,
+					['hash_dec_signed'] = -2019263658,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2116383364,
+					['hash_dec_signed'] = 2116383364,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3695152042,
+					['hash_dec_signed'] = -599815254,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 719802851,
+					['hash_dec_signed'] = 719802851,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2454797056,
+					['hash_dec_signed'] = -1840170240,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1353044056,
+					['hash_dec_signed'] = 1353044056,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3352829302,
+					['hash_dec_signed'] = -942137994,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 186954744,
+					['hash_dec_signed'] = 186954744,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 864946818,
+					['hash_dec_signed'] = 864946818,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4099126971,
+					['hash_dec_signed'] = -195840325,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1709198387,
+					['hash_dec_signed'] = 1709198387,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1468572749,
+					['hash_dec_signed'] = 1468572749,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_004_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[5] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2228517358,
+					['hash_dec_signed'] = -2066449938,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1772409497,
+					['hash_dec_signed'] = 1772409497,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 436828730,
+					['hash_dec_signed'] = 436828730,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 440009573,
+					['hash_dec_signed'] = 440009573,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 263121726,
+					['hash_dec_signed'] = 263121726,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 770881135,
+					['hash_dec_signed'] = 770881135,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2471030136,
+					['hash_dec_signed'] = -1823937160,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2108553835,
+					['hash_dec_signed'] = 2108553835,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1912251213,
+					['hash_dec_signed'] = 1912251213,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2887326182,
+					['hash_dec_signed'] = -1407641114,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3770895777,
+					['hash_dec_signed'] = -524071519,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 351009507,
+					['hash_dec_signed'] = 351009507,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2028868669,
+					['hash_dec_signed'] = 2028868669,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2341403867,
+					['hash_dec_signed'] = -1953563429,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4185077064,
+					['hash_dec_signed'] = -109890232,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 686464008,
+					['hash_dec_signed'] = 686464008,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2665132662,
+					['hash_dec_signed'] = -1629834634,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_005_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[18] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 994536690,
+					['hash_dec_signed'] = 994536690,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[6] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1025183400,
+					['hash_dec_signed'] = 1025183400,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 623103571,
+					['hash_dec_signed'] = 623103571,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1643025786,
+					['hash_dec_signed'] = 1643025786,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1919006827,
+					['hash_dec_signed'] = 1919006827,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3977512758,
+					['hash_dec_signed'] = -317454538,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1948780270,
+					['hash_dec_signed'] = 1948780270,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 555297777,
+					['hash_dec_signed'] = 555297777,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2903163000,
+					['hash_dec_signed'] = -1391804296,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2120703472,
+					['hash_dec_signed'] = 2120703472,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2137195829,
+					['hash_dec_signed'] = 2137195829,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2769686361,
+					['hash_dec_signed'] = -1525280935,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1192656540,
+					['hash_dec_signed'] = 1192656540,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3937076413,
+					['hash_dec_signed'] = -357890883,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1817722458,
+					['hash_dec_signed'] = 1817722458,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1364358652,
+					['hash_dec_signed'] = 1364358652,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3673916823,
+					['hash_dec_signed'] = -621050473,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1417979506,
+					['hash_dec_signed'] = 1417979506,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_006_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[7] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3727020008,
+					['hash_dec_signed'] = -567947288,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 792846821,
+					['hash_dec_signed'] = 792846821,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2789684254,
+					['hash_dec_signed'] = -1505283042,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1286449448,
+					['hash_dec_signed'] = 1286449448,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2937556766,
+					['hash_dec_signed'] = -1357410530,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2454994952,
+					['hash_dec_signed'] = -1839972344,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1775433392,
+					['hash_dec_signed'] = 1775433392,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4025887702,
+					['hash_dec_signed'] = -269079594,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1569400794,
+					['hash_dec_signed'] = 1569400794,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2639450857,
+					['hash_dec_signed'] = -1655516439,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4084035641,
+					['hash_dec_signed'] = -210931655,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 62125078,
+					['hash_dec_signed'] = 62125078,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 726658604,
+					['hash_dec_signed'] = 726658604,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2160430927,
+					['hash_dec_signed'] = -2134536369,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2352534482,
+					['hash_dec_signed'] = -1942432814,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2999959252,
+					['hash_dec_signed'] = -1295008044,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 489478938,
+					['hash_dec_signed'] = 489478938,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_007_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[8] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3370600127,
+					['hash_dec_signed'] = -924367169,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1385015042,
+					['hash_dec_signed'] = 1385015042,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3026895863,
+					['hash_dec_signed'] = -1268071433,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1604325564,
+					['hash_dec_signed'] = 1604325564,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2223721732,
+					['hash_dec_signed'] = -2071245564,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4017859389,
+					['hash_dec_signed'] = -277107907,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1447937531,
+					['hash_dec_signed'] = 1447937531,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1181206804,
+					['hash_dec_signed'] = 1181206804,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3945400824,
+					['hash_dec_signed'] = -349566472,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 83289899,
+					['hash_dec_signed'] = 83289899,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1642850383,
+					['hash_dec_signed'] = 1642850383,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3448303954,
+					['hash_dec_signed'] = -846663342,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1886626446,
+					['hash_dec_signed'] = 1886626446,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3676725024,
+					['hash_dec_signed'] = -618242272,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2735431297,
+					['hash_dec_signed'] = -1559535999,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 668390569,
+					['hash_dec_signed'] = 668390569,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3754984706,
+					['hash_dec_signed'] = -539982590,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_008_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[9] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2997748201,
+					['hash_dec_signed'] = -1297219095,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1683326018,
+					['hash_dec_signed'] = 1683326018,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2700264190,
+					['hash_dec_signed'] = -1594703106,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2158564972,
+					['hash_dec_signed'] = -2136402324,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3119186905,
+					['hash_dec_signed'] = -1175780391,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2853502687,
+					['hash_dec_signed'] = -1441464609,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2021136088,
+					['hash_dec_signed'] = 2021136088,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3198717509,
+					['hash_dec_signed'] = -1096249787,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 34917246,
+					['hash_dec_signed'] = 34917246,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3399912252,
+					['hash_dec_signed'] = -895055044,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1534350217,
+					['hash_dec_signed'] = 1534350217,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 613297523,
+					['hash_dec_signed'] = 613297523,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1752973799,
+					['hash_dec_signed'] = 1752973799,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3932014484,
+					['hash_dec_signed'] = -362952812,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1359066880,
+					['hash_dec_signed'] = 1359066880,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3488672372,
+					['hash_dec_signed'] = -806294924,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2254967684,
+					['hash_dec_signed'] = -2039999612,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_009_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[10] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4137407896,
+					['hash_dec_signed'] = -157559400,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 465258498,
+					['hash_dec_signed'] = 465258498,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 116074515,
+					['hash_dec_signed'] = 116074515,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3761857190,
+					['hash_dec_signed'] = -533110106,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3901501564,
+					['hash_dec_signed'] = -393465732,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 74351192,
+					['hash_dec_signed'] = 74351192,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1618144916,
+					['hash_dec_signed'] = 1618144916,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1785263689,
+					['hash_dec_signed'] = 1785263689,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3388222185,
+					['hash_dec_signed'] = -906745111,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 373001057,
+					['hash_dec_signed'] = 373001057,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2879969800,
+					['hash_dec_signed'] = -1414997496,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2828596431,
+					['hash_dec_signed'] = -1466370865,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3866220133,
+					['hash_dec_signed'] = -428747163,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 539445454,
+					['hash_dec_signed'] = 539445454,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1893781991,
+					['hash_dec_signed'] = 1893781991,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4138407107,
+					['hash_dec_signed'] = -156560189,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2957830128,
+					['hash_dec_signed'] = -1337137168,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_010_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[11] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2240841015,
+					['hash_dec_signed'] = -2054126281,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1408438106,
+					['hash_dec_signed'] = 1408438106,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3798985182,
+					['hash_dec_signed'] = -495982114,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1343081931,
+					['hash_dec_signed'] = 1343081931,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2482891161,
+					['hash_dec_signed'] = -1812076135,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3468688673,
+					['hash_dec_signed'] = -826278623,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 859539007,
+					['hash_dec_signed'] = 859539007,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2443401377,
+					['hash_dec_signed'] = -1851565919,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2222080734,
+					['hash_dec_signed'] = -2072886562,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2381595445,
+					['hash_dec_signed'] = -1913371851,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1305389843,
+					['hash_dec_signed'] = 1305389843,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 621626573,
+					['hash_dec_signed'] = 621626573,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4146457914,
+					['hash_dec_signed'] = -148509382,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1037287971,
+					['hash_dec_signed'] = 1037287971,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 628640804,
+					['hash_dec_signed'] = 628640804,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2281057286,
+					['hash_dec_signed'] = -2013910010,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2406188352,
+					['hash_dec_signed'] = -1888778944,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_011_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[12] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 482292860,
+					['hash_dec_signed'] = 482292860,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4065861840,
+					['hash_dec_signed'] = -229105456,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3672461011,
+					['hash_dec_signed'] = -622506285,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3059166076,
+					['hash_dec_signed'] = -1235801220,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3536417625,
+					['hash_dec_signed'] = -758549671,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2039445071,
+					['hash_dec_signed'] = 2039445071,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1567605956,
+					['hash_dec_signed'] = 1567605956,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1321046055,
+					['hash_dec_signed'] = 1321046055,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1203810198,
+					['hash_dec_signed'] = 1203810198,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1414743118,
+					['hash_dec_signed'] = 1414743118,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1193748334,
+					['hash_dec_signed'] = 1193748334,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 373664797,
+					['hash_dec_signed'] = 373664797,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4225644199,
+					['hash_dec_signed'] = -69323097,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 234649640,
+					['hash_dec_signed'] = 234649640,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3044255087,
+					['hash_dec_signed'] = -1250712209,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 332193580,
+					['hash_dec_signed'] = 332193580,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2621297676,
+					['hash_dec_signed'] = -1673669620,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_012_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[13] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1186635858,
+					['hash_dec_signed'] = 1186635858,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3741365370,
+					['hash_dec_signed'] = -553601926,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3626390666,
+					['hash_dec_signed'] = -668576630,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 306039588,
+					['hash_dec_signed'] = 306039588,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3575671718,
+					['hash_dec_signed'] = -719295578,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 324253830,
+					['hash_dec_signed'] = 324253830,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 843887177,
+					['hash_dec_signed'] = 843887177,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 658185603,
+					['hash_dec_signed'] = 658185603,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2627687363,
+					['hash_dec_signed'] = -1667279933,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3241049223,
+					['hash_dec_signed'] = -1053918073,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3853929319,
+					['hash_dec_signed'] = -441037977,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1305144278,
+					['hash_dec_signed'] = 1305144278,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 914210808,
+					['hash_dec_signed'] = 914210808,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3122291881,
+					['hash_dec_signed'] = -1172675415,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3233333575,
+					['hash_dec_signed'] = -1061633721,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2075824079,
+					['hash_dec_signed'] = 2075824079,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 588525250,
+					['hash_dec_signed'] = 588525250,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_013_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[14] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2216002083,
+					['hash_dec_signed'] = -2078965213,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2549744761,
+					['hash_dec_signed'] = -1745222535,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 771247141,
+					['hash_dec_signed'] = 771247141,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4188718334,
+					['hash_dec_signed'] = -106248962,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 386766442,
+					['hash_dec_signed'] = 386766442,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2045028134,
+					['hash_dec_signed'] = 2045028134,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4003108762,
+					['hash_dec_signed'] = -291858534,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1522562790,
+					['hash_dec_signed'] = 1522562790,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3907997116,
+					['hash_dec_signed'] = -386970180,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4167643306,
+					['hash_dec_signed'] = -127323990,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2676438676,
+					['hash_dec_signed'] = -1618528620,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1257662665,
+					['hash_dec_signed'] = 1257662665,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 723076113,
+					['hash_dec_signed'] = 723076113,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4187045621,
+					['hash_dec_signed'] = -107921675,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 890426757,
+					['hash_dec_signed'] = 890426757,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2406104592,
+					['hash_dec_signed'] = -1888862704,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 395040981,
+					['hash_dec_signed'] = 395040981,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_014_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[15] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3909933651,
+					['hash_dec_signed'] = -385033645,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2807113251,
+					['hash_dec_signed'] = -1487854045,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1227459665,
+					['hash_dec_signed'] = 1227459665,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3501269719,
+					['hash_dec_signed'] = -793697577,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1928818394,
+					['hash_dec_signed'] = 1928818394,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1662226474,
+					['hash_dec_signed'] = 1662226474,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3011360121,
+					['hash_dec_signed'] = -1283607175,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3867569079,
+					['hash_dec_signed'] = -427398217,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 604645064,
+					['hash_dec_signed'] = 604645064,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3253214195,
+					['hash_dec_signed'] = -1041753101,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4127566481,
+					['hash_dec_signed'] = -167400815,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 547915742,
+					['hash_dec_signed'] = 547915742,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2673772469,
+					['hash_dec_signed'] = -1621194827,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3612474713,
+					['hash_dec_signed'] = -682492583,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1774475968,
+					['hash_dec_signed'] = 1774475968,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3155659116,
+					['hash_dec_signed'] = -1139308180,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3844327589,
+					['hash_dec_signed'] = -450639707,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_015_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[16] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2288776154,
+					['hash_dec_signed'] = -2006191142,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 74204665,
+					['hash_dec_signed'] = 74204665,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3849134596,
+					['hash_dec_signed'] = -445832700,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3994459370,
+					['hash_dec_signed'] = -300507926,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1062956085,
+					['hash_dec_signed'] = 1062956085,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2003861717,
+					['hash_dec_signed'] = 2003861717,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1700950890,
+					['hash_dec_signed'] = 1700950890,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4182073854,
+					['hash_dec_signed'] = -112893442,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 616336951,
+					['hash_dec_signed'] = 616336951,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 796247753,
+					['hash_dec_signed'] = 796247753,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2457262150,
+					['hash_dec_signed'] = -1837705146,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 183125517,
+					['hash_dec_signed'] = 183125517,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 401159544,
+					['hash_dec_signed'] = 401159544,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4066854580,
+					['hash_dec_signed'] = -228112716,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3898003266,
+					['hash_dec_signed'] = -396964030,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2733413520,
+					['hash_dec_signed'] = -1561553776,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 583938426,
+					['hash_dec_signed'] = 583938426,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_016_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[17] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3595472271,
+					['hash_dec_signed'] = -699495025,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2753057841,
+					['hash_dec_signed'] = -1541909455,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1707267294,
+					['hash_dec_signed'] = 1707267294,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1282063558,
+					['hash_dec_signed'] = 1282063558,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 158987980,
+					['hash_dec_signed'] = 158987980,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2518943935,
+					['hash_dec_signed'] = -1776023361,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2498778722,
+					['hash_dec_signed'] = -1796188574,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4282896183,
+					['hash_dec_signed'] = -12071113,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3496839074,
+					['hash_dec_signed'] = -798128222,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 78714924,
+					['hash_dec_signed'] = 78714924,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3421839385,
+					['hash_dec_signed'] = -873127911,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1221293104,
+					['hash_dec_signed'] = 1221293104,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 498771722,
+					['hash_dec_signed'] = 498771722,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4262388214,
+					['hash_dec_signed'] = -32579082,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3599441453,
+					['hash_dec_signed'] = -695525843,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 637847969,
+					['hash_dec_signed'] = 637847969,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3352234086,
+					['hash_dec_signed'] = -942733210,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_017_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[18] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3946673397,
+					['hash_dec_signed'] = -348293899,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2311914035,
+					['hash_dec_signed'] = -1983053261,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1175610162,
+					['hash_dec_signed'] = 1175610162,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2161149850,
+					['hash_dec_signed'] = -2133817446,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1942318931,
+					['hash_dec_signed'] = 1942318931,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3670621102,
+					['hash_dec_signed'] = -624346194,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1129288252,
+					['hash_dec_signed'] = 1129288252,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3706415532,
+					['hash_dec_signed'] = -588551764,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 576291658,
+					['hash_dec_signed'] = 576291658,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 200263066,
+					['hash_dec_signed'] = 200263066,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1115640638,
+					['hash_dec_signed'] = 1115640638,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 215489987,
+					['hash_dec_signed'] = 215489987,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 994616327,
+					['hash_dec_signed'] = 994616327,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4294576286,
+					['hash_dec_signed'] = -391010,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2340606033,
+					['hash_dec_signed'] = -1954361263,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 867224239,
+					['hash_dec_signed'] = 867224239,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2486662814,
+					['hash_dec_signed'] = -1808304482,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_018_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[19] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2879633831,
+					['hash_dec_signed'] = -1415333465,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3143492523,
+					['hash_dec_signed'] = -1151474773,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3228876143,
+					['hash_dec_signed'] = -1066091153,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3899549549,
+					['hash_dec_signed'] = -395417747,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3867941296,
+					['hash_dec_signed'] = -427026000,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 339373987,
+					['hash_dec_signed'] = 339373987,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3448112828,
+					['hash_dec_signed'] = -846854468,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1717433230,
+					['hash_dec_signed'] = 1717433230,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2870085539,
+					['hash_dec_signed'] = -1424881757,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3083726234,
+					['hash_dec_signed'] = -1211241062,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2697479630,
+					['hash_dec_signed'] = -1597487666,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 307445061,
+					['hash_dec_signed'] = 307445061,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 654599368,
+					['hash_dec_signed'] = 654599368,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 571008366,
+					['hash_dec_signed'] = 571008366,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1973786461,
+					['hash_dec_signed'] = 1973786461,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 94758104,
+					['hash_dec_signed'] = 94758104,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1396562007,
+					['hash_dec_signed'] = 1396562007,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_019_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[20] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2841000722,
+					['hash_dec_signed'] = -1453966574,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 399469078,
+					['hash_dec_signed'] = 399469078,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2031283199,
+					['hash_dec_signed'] = 2031283199,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2728333995,
+					['hash_dec_signed'] = -1566633301,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3188601412,
+					['hash_dec_signed'] = -1106365884,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1120192881,
+					['hash_dec_signed'] = 1120192881,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3122670066,
+					['hash_dec_signed'] = -1172297230,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 752307168,
+					['hash_dec_signed'] = 752307168,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 429332843,
+					['hash_dec_signed'] = 429332843,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3883841036,
+					['hash_dec_signed'] = -411126260,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3705478035,
+					['hash_dec_signed'] = -589489261,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 332623772,
+					['hash_dec_signed'] = 332623772,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 571455569,
+					['hash_dec_signed'] = 571455569,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3586573779,
+					['hash_dec_signed'] = -708393517,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2207616779,
+					['hash_dec_signed'] = -2087350517,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 237206648,
+					['hash_dec_signed'] = 237206648,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 557173395,
+					['hash_dec_signed'] = 557173395,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_020_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[21] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2344611188,
+					['hash_dec_signed'] = -1950356108,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1904085443,
+					['hash_dec_signed'] = 1904085443,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1751082727,
+					['hash_dec_signed'] = 1751082727,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3906835407,
+					['hash_dec_signed'] = -388131889,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1641181060,
+					['hash_dec_signed'] = 1641181060,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3384348163,
+					['hash_dec_signed'] = -910619133,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 987839219,
+					['hash_dec_signed'] = 987839219,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4271910581,
+					['hash_dec_signed'] = -23056715,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2438602260,
+					['hash_dec_signed'] = -1856365036,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 361562633,
+					['hash_dec_signed'] = 361562633,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 562562858,
+					['hash_dec_signed'] = 562562858,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4183779645,
+					['hash_dec_signed'] = -111187651,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1034478559,
+					['hash_dec_signed'] = 1034478559,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3382095484,
+					['hash_dec_signed'] = -912871812,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 138156328,
+					['hash_dec_signed'] = 138156328,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1135021815,
+					['hash_dec_signed'] = 1135021815,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 160780975,
+					['hash_dec_signed'] = 160780975,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_021_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[22] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3644947867,
+					['hash_dec_signed'] = -650019429,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1826259024,
+					['hash_dec_signed'] = 1826259024,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1665116724,
+					['hash_dec_signed'] = 1665116724,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2774284815,
+					['hash_dec_signed'] = -1520682481,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1103430641,
+					['hash_dec_signed'] = 1103430641,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2920586234,
+					['hash_dec_signed'] = -1374381062,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2801586078,
+					['hash_dec_signed'] = -1493381218,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3139295049,
+					['hash_dec_signed'] = -1155672247,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3386814586,
+					['hash_dec_signed'] = -908152710,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2627254114,
+					['hash_dec_signed'] = -1667713182,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3984769894,
+					['hash_dec_signed'] = -310197402,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 543503256,
+					['hash_dec_signed'] = 543503256,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 593266682,
+					['hash_dec_signed'] = 593266682,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 189197025,
+					['hash_dec_signed'] = 189197025,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3080339781,
+					['hash_dec_signed'] = -1214627515,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1492572364,
+					['hash_dec_signed'] = 1492572364,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3279401082,
+					['hash_dec_signed'] = -1015566214,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_022_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[23] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1604665635,
+					['hash_dec_signed'] = 1604665635,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 469769068,
+					['hash_dec_signed'] = 469769068,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3600240431,
+					['hash_dec_signed'] = -694726865,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3542307388,
+					['hash_dec_signed'] = -752659908,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2425969086,
+					['hash_dec_signed'] = -1868998210,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 889049917,
+					['hash_dec_signed'] = 889049917,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2181127786,
+					['hash_dec_signed'] = -2113839510,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1773478186,
+					['hash_dec_signed'] = 1773478186,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 254066903,
+					['hash_dec_signed'] = 254066903,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 17161652,
+					['hash_dec_signed'] = 17161652,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3692291417,
+					['hash_dec_signed'] = -602675879,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1513708555,
+					['hash_dec_signed'] = 1513708555,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3379337096,
+					['hash_dec_signed'] = -915630200,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 464056288,
+					['hash_dec_signed'] = 464056288,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2046857347,
+					['hash_dec_signed'] = 2046857347,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 780520050,
+					['hash_dec_signed'] = 780520050,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2778936412,
+					['hash_dec_signed'] = -1516030884,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_023_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[24] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1303356467,
+					['hash_dec_signed'] = 1303356467,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2059530093,
+					['hash_dec_signed'] = 2059530093,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2184788560,
+					['hash_dec_signed'] = -2110178736,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 918610351,
+					['hash_dec_signed'] = 918610351,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 505060812,
+					['hash_dec_signed'] = 505060812,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3915088917,
+					['hash_dec_signed'] = -379878379,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1835598870,
+					['hash_dec_signed'] = 1835598870,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3675782574,
+					['hash_dec_signed'] = -619184722,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2805694745,
+					['hash_dec_signed'] = -1489272551,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 743685742,
+					['hash_dec_signed'] = 743685742,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2127735042,
+					['hash_dec_signed'] = 2127735042,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 918148258,
+					['hash_dec_signed'] = 918148258,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 704800264,
+					['hash_dec_signed'] = 704800264,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2183487919,
+					['hash_dec_signed'] = -2111479377,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2459863668,
+					['hash_dec_signed'] = -1835103628,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 176933481,
+					['hash_dec_signed'] = 176933481,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2477165059,
+					['hash_dec_signed'] = -1817802237,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_024_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[25] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1769735681,
+					['hash_dec_signed'] = 1769735681,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 517266857,
+					['hash_dec_signed'] = 517266857,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 843248893,
+					['hash_dec_signed'] = 843248893,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1557718331,
+					['hash_dec_signed'] = 1557718331,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4094561795,
+					['hash_dec_signed'] = -200405501,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2062355027,
+					['hash_dec_signed'] = 2062355027,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4150298338,
+					['hash_dec_signed'] = -144668958,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3067839996,
+					['hash_dec_signed'] = -1227127300,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3597829160,
+					['hash_dec_signed'] = -697138136,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2436736857,
+					['hash_dec_signed'] = -1858230439,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2821365455,
+					['hash_dec_signed'] = -1473601841,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3215852400,
+					['hash_dec_signed'] = -1079114896,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3453275799,
+					['hash_dec_signed'] = -841691497,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2342491656,
+					['hash_dec_signed'] = -1952475640,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2574176039,
+					['hash_dec_signed'] = -1720791257,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 323285657,
+					['hash_dec_signed'] = 323285657,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1517957121,
+					['hash_dec_signed'] = 1517957121,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_025_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[26] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1480607404,
+					['hash_dec_signed'] = 1480607404,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 174221879,
+					['hash_dec_signed'] = 174221879,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2783627815,
+					['hash_dec_signed'] = -1511339481,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_DARKEST_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 375000866,
+					['hash_dec_signed'] = 375000866,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_DARK_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1176649688,
+					['hash_dec_signed'] = 1176649688,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_DARK_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2006167823,
+					['hash_dec_signed'] = 2006167823,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_DARK_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1035817531,
+					['hash_dec_signed'] = 1035817531,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 133331768,
+					['hash_dec_signed'] = 133331768,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4101816652,
+					['hash_dec_signed'] = -193150644,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_JET_BLACK',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3698087123,
+					['hash_dec_signed'] = -596880173,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_LIGHT_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1204671856,
+					['hash_dec_signed'] = 1204671856,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_LIGHT_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1491872637,
+					['hash_dec_signed'] = 1491872637,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_LIGHT_GINGER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3043073030,
+					['hash_dec_signed'] = -1251894266,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_LIGHT_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1897502001,
+					['hash_dec_signed'] = 1897502001,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_MEDIUM_BROWN',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 547295182,
+					['hash_dec_signed'] = 547295182,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_SALT_PEPPER',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2695590633,
+					['hash_dec_signed'] = -1599376663,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_STRAWBERRY_BLONDE',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4185967414,
+					['hash_dec_signed'] = -108999882,
+					['hashname'] = 'CLOTHING_ITEM_M_HAIR_028_UNCLE_GREY',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[27] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 685767930,
+					['hash_dec_signed'] = 685767930,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1134333556,
+					['hash_dec_signed'] = 1134333556,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1236989883,
+					['hash_dec_signed'] = 1236989883,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1327556610,
+					['hash_dec_signed'] = 1327556610,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1712720578,
+					['hash_dec_signed'] = 1712720578,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1766804827,
+					['hash_dec_signed'] = 1766804827,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2211514444,
+					['hash_dec_signed'] = -2083452852,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2547609907,
+					['hash_dec_signed'] = -1747357389,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2706041597,
+					['hash_dec_signed'] = -1588925699,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2965455503,
+					['hash_dec_signed'] = -1329511793,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3186428748,
+					['hash_dec_signed'] = -1108538548,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3342711908,
+					['hash_dec_signed'] = -952255388,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3367046862,
+					['hash_dec_signed'] = -927920434,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3527780349,
+					['hash_dec_signed'] = -767186947,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3899900424,
+					['hash_dec_signed'] = -395066872,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3925546859,
+					['hash_dec_signed'] = -369420437,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3981639676,
+					['hash_dec_signed'] = -313327620,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[28] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 182670013,
+					['hash_dec_signed'] = 182670013,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 204224900,
+					['hash_dec_signed'] = 204224900,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 371660699,
+					['hash_dec_signed'] = 371660699,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 591398697,
+					['hash_dec_signed'] = 591398697,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[5] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1415041389,
+					['hash_dec_signed'] = 1415041389,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[6] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1512695305,
+					['hash_dec_signed'] = 1512695305,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[7] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1707184427,
+					['hash_dec_signed'] = 1707184427,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[8] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2010746309,
+					['hash_dec_signed'] = 2010746309,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[9] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2317089347,
+					['hash_dec_signed'] = -1977877949,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[10] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2422937068,
+					['hash_dec_signed'] = -1872030228,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[11] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 2424803532,
+					['hash_dec_signed'] = -1870163764,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[12] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3070836718,
+					['hash_dec_signed'] = -1224130578,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[13] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3543688531,
+					['hash_dec_signed'] = -751278765,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[14] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3841648547,
+					['hash_dec_signed'] = -453318749,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[15] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 3889372983,
+					['hash_dec_signed'] = -405594313,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[16] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4047866788,
+					['hash_dec_signed'] = -247100508,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[17] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4207234788,
+					['hash_dec_signed'] = -87732508,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			},
+			[29] = {
+				[1] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 516967315,
+					['hash_dec_signed'] = 516967315,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[2] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 740714047,
+					['hash_dec_signed'] = 740714047,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[3] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 1353658196,
+					['hash_dec_signed'] = 1353658196,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+				[4] = {
+					['category_hash'] = 2253063086,
+					['category_hash_dec_signed'] = -2041904210,
+					['category_hashname'] = 'hair',
+					['hash'] = 4012829781,
+					['hash_dec_signed'] = -282137515,
+					['hashname'] = '',
+					['is_multiplayer'] = true,
+					['ped_type'] = 'male'
+				},
+			}
+		}
+	}
+}

--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -1047,6 +1047,11 @@ end
 
 --- A function to standardize a object of categories
 local function standardizeSkin(object)
+--  local user = jo.User:get(source)
+--  local rpName = user:getRPName()
+  
+--  print(string.format("Standarding Skin Part 1 - Recieved skin data for character: %s | Data: %s", rpName, json.encode(object)))
+
   object = table.copy(object)
   local standard = {}
 
@@ -1560,6 +1565,215 @@ local function standardizeSkin(object)
     -- standard.overlays.masks = {},
     -- standard.overlays.complex = {},
     -- standard.overlays.disc = {},
+  elseif jo.framework:is("RedEM2023") then
+    local skin_tone = { 1, 4, 3, 5, 2, 6 }
+    local heads = {
+      mp_male = { [16] = 18, [17] = 21, [18] = 22, [19] = 25, [20] = 28 },
+      mp_female = { [17] = 20, [18] = 22, [19] = 27, [20] = 28 }
+    }
+    local bodies = { 2, 1, 3, 4, 5, 6 }
+
+    standard.model = table.extract(object, "sex") == 2 and "mp_female" or "mp_male"
+    standard.bodiesIndex = bodies[object.body_size] or object.body_size
+    object.body_size = nil
+    standard.eyesIndex = table.extract(object, "eyes_color")
+    local head = object.head or 1
+    object.head = nil
+    standard.headIndex = heads[standard.model][math.ceil(head / 6)] or math.ceil(head / 6)
+    standard.skinTone = skin_tone[table.extract(object, "skin_tone")]
+    standard.teethIndex = table.extract(object, "teeth")
+    standard.hair = table.extract(object, "hair")
+    if standard.model == "mp_male" then
+      standard.beards_complete = table.extract(object, "beard")
+    end
+    standard.bodyScale = convertToPercent(table.extract(object, "height"))
+    standard.bodyWeight = table.extract(object, "body_waist")
+
+    standard.expressions = {
+      arms = table.extract(object, "arms_size"),
+      calves = table.extract(object, "calves_size"),
+      cheekbonesDepth = table.extract(object, "cheekbones_depth"),
+      cheekbonesHeight = table.extract(object, "cheekbones_height"),
+      cheekbonesWidth = table.extract(object, "cheekbones_width"),
+      chest = table.extract(object, "chest_size"),
+      chinDepth = table.extract(object, "chin_depth"),
+      chinHeight = table.extract(object, "chin_height"),
+      chinWidth = table.extract(object, "chin_width"),
+      earlobes = table.extract(object, "earlobe_size"),
+      earsAngle = table.extract(object, "ears_angle"),
+      earsDepth = table.extract(object, "eyebrow_depth"),
+      earsHeight = table.extract(object, "ears_height"),
+      earsWidth = table.extract(object, "ears_width"),
+      eyebrowDepth = table.extract(object, "face_depth"),
+      eyebrowHeight = table.extract(object, "eyebrow_height"),
+      eyebrowWidth = table.extract(object, "eyebrow_width"),
+      eyelidHeight = table.extract(object, "eyelid_height"),
+      eyelidLeft = table.extract(object, "eyelid_left"),
+      eyelidRight = table.extract(object, "eyelid_right"),
+      eyelidWidth = table.extract(object, "eyelid_width"),
+      eyesAngle = table.extract(object, "eyes_angle"),
+      eyesDepth = table.extract(object, "eyes_depth"),
+      eyesDistance = table.extract(object, "eyes_distance"),
+      eyesHeight = table.extract(object, "eyes_height"),
+      faceWidth = table.extract(object, "face_width"),
+      headWidth = table.extract(object, "head_width"),
+      hip = table.extract(object, "hips_size"),
+      jawDepth = table.extract(object, "jaw_depth"),
+      jawHeight = table.extract(object, "jaw_height"),
+      jawWidth = table.extract(object, "jaw_width"),
+      jawY = table.extract(object, "jawY"),
+      lowerLipDepth = table.extract(object, "lower_lip_depth"),
+      lowerLipHeight = table.extract(object, "lower_lip_height"),
+      lowerLipWidth = table.extract(object, "lower_lip_width"),
+      mouthConerLeftDepth = table.extract(object, "mouth_corner_left_depth"),
+      mouthConerLeftHeight = table.extract(object, "mouth_corner_left_height"),
+      mouthConerLeftLipsDistance = table.extract(object, "mouth_corner_left_lips_distance"),
+      mouthConerLeftWidth = table.extract(object, "mouth_corner_left_width"),
+      mouthConerRightDepth = table.extract(object, "mouth_corner_right_depth"),
+      mouthConerRightHeight = table.extract(object, "mouth_corner_right_height"),
+      mouthConerRightLipsDistance = table.extract(object, "mouth_corner_right_lips_distance"),
+      mouthConerRightWidth = table.extract(object, "mouth_corner_right_width"),
+      mouthDepth = table.extract(object, "mouth_depth"),
+      mouthWidth = table.extract(object, "mouth_width"),
+      mouthX = table.extract(object, "mouth_x_pos"),
+      mouthY = table.extract(object, "mouth_y_pos"),
+      neckDepth = table.extract(object, "neck_depth"),
+      neckWidth = table.extract(object, "neck_width"),
+      noseAngle = table.extract(object, "nose_angle"),
+      noseCurvature = table.extract(object, "nose_curvature"),
+      noseHeight = table.extract(object, "nose_height"),
+      noseSize = table.extract(object, "nose_size"),
+      noseWidth = table.extract(object, "nose_width"),
+      nostrilsDistance = table.extract(object, "nostrils_distance"),
+      shoulderBlades = table.extract(object, "back_muscle"),
+      shoulders = table.extract(object, "uppr_shoulder_size"),
+      shoulderThickness = table.extract(object, "back_shoulder_thickness"),
+      thighs = table.extract(object, "tight_size"),
+      upperLipDepth = table.extract(object, "upper_lip_depth"),
+      upperLipHeight = table.extract(object, "upper_lip_height"),
+      upperLipWidth = table.extract(object, "upper_lip_width"),
+      waist = table.extract(object, "waist_width"),
+    }
+
+    standard.overlays = {}
+    standard.overlays.ageing = object.ageing_t and {
+      id = decrease(object.ageing_t),
+      opacity = convertToPercent(object.ageing_op)
+    }
+    object.ageing_t = nil
+    object.ageing_op = nil
+
+    standard.overlays.beard = object.beardstabble_t and {
+      id = object.beardstabble_t,
+      opacity = convertToPercent(object.beardstabble_op)
+    }
+    object.beardstabble_t = nil
+    object.beardstabble_op = nil
+
+    standard.overlays.blush = object.blush_t and {
+      id = decrease(object.blush_t),
+      palette = object.blush_id,
+      tint0 = object.blush_c1,
+      opacity = convertToPercent(object.blush_op)
+    }
+    object.blush_t = nil
+    object.blush_id = nil
+    object.blush_c1 = nil
+    object.blush_op = nil
+
+    standard.overlays.eyebrow = object.eyebrows_t and (function()
+      local id = decrease(object.eyebrows_t)
+      local sexe = "m"
+      if id > 15 then
+        id = id - 15
+        sexe = "f"
+      end
+      return {
+        id = id,
+        sexe = sexe,
+        palette = object.eyebrows_id,
+        tint0 = object.eyebrows_c1,
+        opacity = convertToPercent(object.eyebrows_op)
+      }
+    end)()
+    object.eyebrows_t = nil
+    object.eyebrows_id = nil
+    object.eyebrows_c1 = nil
+    object.eyebrows_op = nil
+
+    standard.overlays.eyeliner = object.eyeliners_t and {
+      id = 0,
+      sheetGrid = decrease(object.eyeliners_t),
+      palette = object.eyeliners_id,
+      tint0 = object.eyeliners_c1,
+      opacity = convertToPercent(object.eyeliners_op)
+    }
+    object.eyeliners_t = nil
+    object.eyeliners_id = nil
+    object.eyeliners_c1 = nil
+    object.eyeliners_op = nil
+
+    standard.overlays.eyeshadow = object.shadows_t and {
+      id = 0,
+      sheetGrid = decrease(object.shadows_t),
+      palette = object.shadows_id,
+      tint0 = object.shadows_c1,
+      opacity = convertToPercent(object.shadows_op)
+    }
+    object.shadows_t = nil
+    object.shadows_id = nil
+    object.shadows_c1 = nil
+    object.shadows_op = nil
+
+    standard.overlays.freckles = object.freckles_t and {
+      id = decrease(object.freckles_t),
+      opacity = convertToPercent(object.freckles_op)
+    }
+    object.freckles_t = nil
+    object.freckles_op = nil
+
+    standard.overlays.lipstick = object.lipsticks_t and {
+      id = 0,
+      sheetGrid = decrease(object.lipsticks_t),
+      palette = object.lipsticks_id,
+      tint0 = object.lipsticks_c1,
+      tint1 = object.lipsticks_c2,
+      opacity = convertToPercent(object.lipsticks_op)
+    }
+    object.lipsticks_t = nil
+    object.lipsticks_id = nil
+    object.lipsticks_c1 = nil
+    object.lipsticks_c2 = nil
+    object.lipsticks_op = nil
+
+    standard.overlays.moles = object.moles_t and {
+      id = decrease(object.moles_t),
+      opacity = convertToPercent(object.moles_op)
+    }
+    object.moles_t = nil
+    object.moles_op = nil
+
+    standard.overlays.scar = object.scars_t and {
+      id = decrease(object.scars_t),
+      opacity = convertToPercent(object.scars_op)
+    }
+    object.scars_t = nil
+    object.scars_op = nil
+
+    standard.overlays.spots = object.spots_t and {
+      id = decrease(object.spots_t),
+      opacity = convertToPercent(object.spots_op)
+    }
+    object.spots_t = nil
+    object.spots_op = nil
+
+    -- standard.overlays.acne = {},
+    -- standard.overlays.foundation = {},
+    -- standard.overlays.grime = {},
+    -- standard.overlays.hair = {},
+    -- standard.overlays.masks = {},
+    -- standard.overlays.complex = {},
+    -- standard.overlays.disc = {},
   end
 
   if jo.debug then
@@ -1590,14 +1804,45 @@ local function standardizeSkin(object)
   clearOverlaysTable(standard.overlays)
 
   if standard.hair and type(standard.hair) ~= "table" then
-    standard.hair = {
+    standard.hair = { -- standardize hair table
       hash = standard.hair
     }
+    if standard.hair.model ~= nil and tonumber(standard.hair.model) > 0 then -- redemrp/reboot/rsg catch, or any other framework that saves hair/beards like this
+      local model = tonumber(standard.hair.model)
+      local texture = tonumber(standard.hair.texture)
+
+      if standard.model == "mp_male" then
+        if hairs_list["male"]["hair"][model] and hairs_list["male"]["hair"][model][texture] then -- compare against the list
+          standard.hair.hash = hairs_list["male"]["hair"][model] and hairs_list["male"]["hair"][model][texture].hash -- set the hash from the list
+        end
+      else
+        if hairs_list["female"]["hair"][model] and hairs_list["female"]["hair"][model][texture] then
+          standard.hair.hash = hairs_list["female"]["hair"][model][texture].hash
+        end
+      end
+    end
   end
+
   if standard.beards_complete and type(standard.beards_complete) ~= "table" then
     standard.beards_complete = {
       hash = standard.beards_complete
     }
+    if standard.beards_complete.model ~= nil and tonumber(standard.beards_complete.model) > 0 then
+      local model = tonumber(standard.beards_complete.model)
+      local texture = tonumber(standard.beards_complete.texture)
+      if hairs_list["male"]["beard"][model] and hairs_list["male"]["beard"][model][texture] then
+        standard.beards_complete.hash = hairs_list["male"]["beard"][model][texture].hash
+      end    
+    end
+  end
+
+  if standard.teethIndex == nil then -- rsg/redem/reboot, if there's no teethIndex established, populate one as default.
+    standard.teethIndex = 0
+  end
+
+  if #tostring(math.abs(standard.teethIndex)) > 1 then -- convert to a string, then count the # of characters. If there's more than 1 character, teethIndex was originally saved as a hash & should be updated as such.
+    standard.teethHash = standard.teethIndex
+    standard.teethIndex = nil
   end
 
   if jo.debug then
@@ -1899,6 +2144,223 @@ local function revertSkin(standard)
 
     reverted.overlays = table.copy(standard.overlays)
   elseif jo.framework:is("RSG") then
+    local function revertPercent(value)
+      if not value then return nil end
+      return math.ceil((value) * 100)
+    end
+
+    local skin_tone = { 1, 4, 3, 5, 2, 6 }
+    local heads = {
+      mp_male = { [16] = 18, [17] = 21, [18] = 22, [19] = 25, [20] = 28 },
+      mp_female = { [17] = 20, [18] = 22, [19] = 27, [20] = 28 }
+    }
+    local bodies = { 2, 1, 3, 4, 5, 6 }
+
+    reverted.sex = standard.model == "mp_female" and 2 or 1
+    _, reverted.body_size = table.find(bodies, function(value) return value == standard.bodiesIndex end)
+    standard.bodiesIndex = nil
+    reverted.eyes_color = table.extract(standard, "eyesIndex")
+    _, reverted.head = table.find(heads[standard.model], function(value) return value == standard.headIndex end)
+    reverted.head = (reverted.head or standard.headIndex) * 6
+    standard.headIndex = nil
+    _, reverted.skin_tone = table.find(skin_tone, function(value, i) return value == standard.skinTone end)
+    standard.skinTone = nil
+    reverted.teeth = table.extract(standard, "teethIndex")
+    reverted.hair = table.extract(standard, "hair")
+    if standard.model == "mp_male" then
+      reverted.beard = table.extract(standard, "beards_complete")
+    end
+    reverted.height = revertPercent(table.extract(standard, "bodyScale"))
+    reverted.body_waist = table.extract(standard, "bodyWeight")
+    standard.model = nil
+
+    reverted.arms_size = revertPercent(table.extract(standard.expressions, "arms"))
+    reverted.calves_size = revertPercent(table.extract(standard.expressions, "calves"))
+    reverted.cheekbones_depth = revertPercent(table.extract(standard.expressions, "cheekbonesDepth"))
+    reverted.cheekbones_height = revertPercent(table.extract(standard.expressions, "cheekbonesHeight"))
+    reverted.cheekbones_width = revertPercent(table.extract(standard.expressions, "cheekbonesWidth"))
+    reverted.chest_size = revertPercent(table.extract(standard.expressions, "chest"))
+    reverted.chin_depth = revertPercent(table.extract(standard.expressions, "chinDepth"))
+    reverted.chin_height = revertPercent(table.extract(standard.expressions, "chinHeight"))
+    reverted.chin_width = revertPercent(table.extract(standard.expressions, "chinWidth"))
+    reverted.earlobe_size = revertPercent(table.extract(standard.expressions, "earlobes"))
+    reverted.ears_angle = revertPercent(table.extract(standard.expressions, "earsAngle"))
+    reverted.eyebrow_depth = revertPercent(table.extract(standard.expressions, "earsDepth"))
+    reverted.ears_height = revertPercent(table.extract(standard.expressions, "earsHeight"))
+    reverted.ears_width = revertPercent(table.extract(standard.expressions, "earsWidth"))
+    reverted.face_depth = revertPercent(table.extract(standard.expressions, "eyebrowDepth"))
+    reverted.eyebrow_height = revertPercent(table.extract(standard.expressions, "eyebrowHeight"))
+    reverted.eyebrow_width = revertPercent(table.extract(standard.expressions, "eyebrowWidth"))
+    reverted.eyelid_height = revertPercent(table.extract(standard.expressions, "eyelidHeight"))
+    reverted.eyelid_left = revertPercent(table.extract(standard.expressions, "eyelidLeft"))
+    reverted.eyelid_right = revertPercent(table.extract(standard.expressions, "eyelidRight"))
+    reverted.eyelid_width = revertPercent(table.extract(standard.expressions, "eyelidWidth"))
+    reverted.eyes_angle = revertPercent(table.extract(standard.expressions, "eyesAngle"))
+    reverted.eyes_depth = revertPercent(table.extract(standard.expressions, "eyesDepth"))
+    reverted.eyes_distance = revertPercent(table.extract(standard.expressions, "eyesDistance"))
+    reverted.eyes_height = revertPercent(table.extract(standard.expressions, "eyesHeight"))
+    reverted.face_width = revertPercent(table.extract(standard.expressions, "faceWidth"))
+    reverted.head_width = revertPercent(table.extract(standard.expressions, "headWidth"))
+    reverted.hips_size = revertPercent(table.extract(standard.expressions, "hip"))
+    reverted.jaw_depth = revertPercent(table.extract(standard.expressions, "jawDepth"))
+    reverted.jaw_height = revertPercent(table.extract(standard.expressions, "jawHeight"))
+    reverted.jaw_width = revertPercent(table.extract(standard.expressions, "jawWidth"))
+    reverted.jawY = revertPercent(table.extract(standard.expressions, "jawY"))
+    reverted.lower_lip_depth = revertPercent(table.extract(standard.expressions, "lowerLipDepth"))
+    reverted.lower_lip_height = revertPercent(table.extract(standard.expressions, "lowerLipHeight"))
+    reverted.lower_lip_width = revertPercent(table.extract(standard.expressions, "lowerLipWidth"))
+    reverted.mouth_corner_left_depth = revertPercent(table.extract(standard.expressions, "mouthConerLeftDepth"))
+    reverted.mouth_corner_left_height = revertPercent(table.extract(standard.expressions, "mouthConerLeftHeight"))
+    reverted.mouth_corner_left_lips_distance = revertPercent(table.extract(standard.expressions, "mouthConerLeftLipsDistance"))
+    reverted.mouth_corner_left_width = revertPercent(table.extract(standard.expressions, "mouthConerLeftWidth"))
+    reverted.mouth_corner_right_depth = revertPercent(table.extract(standard.expressions, "mouthConerRightDepth"))
+    reverted.mouth_corner_right_height = revertPercent(table.extract(standard.expressions, "mouthConerRightHeight"))
+    reverted.mouth_corner_right_lips_distance = revertPercent(table.extract(standard.expressions, "mouthConerRightLipsDistance"))
+    reverted.mouth_corner_right_width = revertPercent(table.extract(standard.expressions, "mouthConerRightWidth"))
+    reverted.mouth_depth = revertPercent(table.extract(standard.expressions, "mouthDepth"))
+    reverted.mouth_width = revertPercent(table.extract(standard.expressions, "mouthWidth"))
+    reverted.mouth_x_pos = revertPercent(table.extract(standard.expressions, "mouthX"))
+    reverted.mouth_y_pos = revertPercent(table.extract(standard.expressions, "mouthY"))
+    reverted.neck_depth = revertPercent(table.extract(standard.expressions, "neckDepth"))
+    reverted.neck_width = revertPercent(table.extract(standard.expressions, "neckWidth"))
+    reverted.nose_angle = revertPercent(table.extract(standard.expressions, "noseAngle"))
+    reverted.nose_curvature = revertPercent(table.extract(standard.expressions, "noseCurvature"))
+    reverted.nose_height = revertPercent(table.extract(standard.expressions, "noseHeight"))
+    reverted.nose_size = revertPercent(table.extract(standard.expressions, "noseSize"))
+    reverted.nose_width = revertPercent(table.extract(standard.expressions, "noseWidth"))
+    reverted.nostrils_distance = revertPercent(table.extract(standard.expressions, "nostrilsDistance"))
+    reverted.back_muscle = revertPercent(table.extract(standard.expressions, "shoulderBlades"))
+    reverted.uppr_shoulder_size = revertPercent(table.extract(standard.expressions, "shoulders"))
+    reverted.back_shoulder_thickness = revertPercent(table.extract(standard.expressions, "shoulderThickness"))
+    reverted.tight_size = revertPercent(table.extract(standard.expressions, "thighs"))
+    reverted.upper_lip_depth = revertPercent(table.extract(standard.expressions, "upperLipDepth"))
+    reverted.upper_lip_height = revertPercent(table.extract(standard.expressions, "upperLipHeight"))
+    reverted.upper_lip_width = revertPercent(table.extract(standard.expressions, "upperLipWidth"))
+    reverted.waist_width = revertPercent(table.extract(standard.expressions, "waist"))
+
+    if standard.overlays.ageing then
+      reverted.ageing_t = increase(standard.overlays.ageing.id)
+      reverted.ageing_op = revertPercent(standard.overlays.ageing.opacity)
+      standard.overlays.ageing.id = nil
+      standard.overlays.ageing.opacity = nil
+    end
+    if standard.overlays.beard then
+      reverted.beardstabble_t = standard.overlays.beard.id
+      reverted.beardstabble_op = revertPercent(standard.overlays.beard.opacity)
+      standard.overlays.beard.id = nil
+      standard.overlays.beard.opacity = nil
+    end
+    if standard.overlays.blush then
+      reverted.blush_t = increase(standard.overlays.blush.id)
+      reverted.blush_id = standard.overlays.blush.palette
+      reverted.blush_c1 = standard.overlays.blush.tint0
+      reverted.blush_op = revertPercent(standard.overlays.blush.opacity)
+      standard.overlays.blush.id = nil
+      standard.overlays.blush.palette = nil
+      standard.overlays.blush.tint0 = nil
+      standard.overlays.blush.opacity = nil
+    end
+    if standard.overlays.eyebrow then
+      reverted.eyebrows_t = increase(standard.overlays.eyebrow.id)
+      if standard.overlays.eyebrow.sexe == "f" then
+        reverted.eyebrows_t = reverted.eyebrows_t + 15
+      end
+      reverted.eyebrows_id = standard.overlays.eyebrow.palette
+      reverted.eyebrows_c1 = standard.overlays.eyebrow.tint0
+      reverted.eyebrows_op = revertPercent(standard.overlays.eyebrow.opacity)
+      standard.overlays.eyebrow.id = nil
+      standard.overlays.eyebrow.palette = nil
+      standard.overlays.eyebrow.tint0 = nil
+      standard.overlays.eyebrow.opacity = nil
+      standard.overlays.eyebrow.sexe = nil
+    end
+    if standard.overlays.eyeliner then
+      reverted.eyeliners_t = increase(standard.overlays.eyeliner.sheetGrid)
+      reverted.eyeliners_id = standard.overlays.eyeliner.palette
+      reverted.eyeliners_c1 = standard.overlays.eyeliner.tint0
+      reverted.eyeliners_op = revertPercent(standard.overlays.eyeliner.opacity)
+      standard.overlays.eyeliner.sheetGrid = nil
+      standard.overlays.eyeliner.palette = nil
+      standard.overlays.eyeliner.tint0 = nil
+      standard.overlays.eyeliner.opacity = nil
+    end
+    if standard.overlays.eyeshadow then
+      reverted.shadows_t = increase(standard.overlays.eyeshadow.sheetGrid)
+      reverted.shadows_id = standard.overlays.eyeshadow.palette
+      reverted.shadows_c1 = standard.overlays.eyeshadow.tint0
+      reverted.shadows_c2 = standard.overlays.eyeshadow.tint1
+      reverted.shadows_c3 = standard.overlays.eyeshadow.tint2
+      reverted.shadows_op = revertPercent(standard.overlays.eyeshadow.opacity)
+      standard.overlays.eyeshadow.sheetGrid = nil
+      standard.overlays.eyeshadow.palette = nil
+      standard.overlays.eyeshadow.tint0 = nil
+      standard.overlays.eyeshadow.tint1 = nil
+      standard.overlays.eyeshadow.tint2 = nil
+      standard.overlays.eyeshadow.opacity = nil
+    end
+    if standard.overlays.freckles then
+      reverted.freckles_t = increase(standard.overlays.freckles.id)
+      reverted.freckles_op = revertPercent(standard.overlays.freckles.opacity)
+      standard.overlays.freckles.id = nil
+      standard.overlays.freckles.opacity = nil
+    end
+    if standard.overlays.lipstick then
+      reverted.lipsticks_t = increase(standard.overlays.lipstick.sheetGrid)
+      reverted.lipsticks_id = standard.overlays.lipstick.palette
+      reverted.lipsticks_c1 = standard.overlays.lipstick.tint0
+      reverted.lipsticks_c2 = standard.overlays.lipstick.tint1
+      reverted.lipsticks_c3 = standard.overlays.lipstick.tint2
+      reverted.lipsticks_op = revertPercent(standard.overlays.lipstick.opacity)
+      standard.overlays.lipstick.sheetGrid = nil
+      standard.overlays.lipstick.palette = nil
+      standard.overlays.lipstick.tint0 = nil
+      standard.overlays.lipstick.tint1 = nil
+      standard.overlays.lipstick.tint2 = nil
+      standard.overlays.lipstick.opacity = nil
+    end
+    if standard.overlays.moles then
+      reverted.moles_t = increase(standard.overlays.moles.id)
+      reverted.moles_op = revertPercent(standard.overlays.moles.opacity)
+      standard.overlays.moles.id = nil
+      standard.overlays.moles.opacity = nil
+    end
+    if standard.overlays.scar then
+      reverted.scars_t = increase(standard.overlays.scar.id)
+      reverted.scars_op = revertPercent(standard.overlays.scar.opacity)
+      standard.overlays.scar.id = nil
+      standard.overlays.scar.opacity = nil
+    end
+    if standard.overlays.spots then
+      reverted.spots_t = increase(standard.overlays.spots.id)
+      reverted.spots_op = revertPercent(standard.overlays.spots.opacity)
+      standard.overlays.spots.id = nil
+      standard.overlays.spots.opacity = nil
+    end
+
+
+    for key, data in pairs(standard.overlays) do
+      if table.count(data) == 0 then
+        standard.overlays[key] = nil
+      end
+    end
+    if table.count(standard.overlays) == 0 then
+      standard.overlays = nil
+    end
+    if table.count(standard.expressions) == 0 then
+      standard.expressions = nil
+    end
+
+    if jo.debug then
+      if table.count(standard) > 0 then
+        eprint("Skin keys not reverted")
+        for key, value in pairs(standard) do
+          print(key, type(value) == "table" and json.encode(value) or value)
+        end
+      else
+        gprint("All skin keys reverted")
+      end
+    end
+  elseif jo.framework:is("RedEM2023") then
     local function revertPercent(value)
       if not value then return nil end
       return math.ceil((value) * 100)

--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -1047,11 +1047,6 @@ end
 
 --- A function to standardize a object of categories
 local function standardizeSkin(object)
---  local user = jo.User:get(source)
---  local rpName = user:getRPName()
-  
---  print(string.format("Standarding Skin Part 1 - Recieved skin data for character: %s | Data: %s", rpName, json.encode(object)))
-
   object = table.copy(object)
   local standard = {}
 
@@ -1448,7 +1443,7 @@ local function standardizeSkin(object)
 
     standard.overlays = {}
     standard.overlays.ageing = object.ageing_t and {
-      id = decrease(object.ageing_t),
+      id = object.ageing_t,
       opacity = convertToPercent(object.ageing_op)
     }
     object.ageing_t = nil
@@ -1462,7 +1457,7 @@ local function standardizeSkin(object)
     object.beardstabble_op = nil
 
     standard.overlays.blush = object.blush_t and {
-      id = decrease(object.blush_t),
+      id = object.blush_t,
       palette = object.blush_id,
       tint0 = object.blush_c1,
       opacity = convertToPercent(object.blush_op)
@@ -1473,7 +1468,7 @@ local function standardizeSkin(object)
     object.blush_op = nil
 
     standard.overlays.eyebrow = object.eyebrows_t and (function()
-      local id = decrease(object.eyebrows_t)
+      local id = object.eyebrows_t
       local sexe = "m"
       if id > 15 then
         id = id - 15
@@ -1493,8 +1488,8 @@ local function standardizeSkin(object)
     object.eyebrows_op = nil
 
     standard.overlays.eyeliner = object.eyeliners_t and {
-      id = 0,
-      sheetGrid = decrease(object.eyeliners_t),
+      id = object.eyeliners_t,
+      sheetGrid = 0,
       palette = object.eyeliners_id,
       tint0 = object.eyeliners_c1,
       opacity = convertToPercent(object.eyeliners_op)
@@ -1505,8 +1500,8 @@ local function standardizeSkin(object)
     object.eyeliners_op = nil
 
     standard.overlays.eyeshadow = object.shadows_t and {
-      id = 0,
-      sheetGrid = decrease(object.shadows_t),
+      id = object.shadows_t,
+      sheetGrid = 0,
       palette = object.shadows_id,
       tint0 = object.shadows_c1,
       opacity = convertToPercent(object.shadows_op)
@@ -1517,15 +1512,15 @@ local function standardizeSkin(object)
     object.shadows_op = nil
 
     standard.overlays.freckles = object.freckles_t and {
-      id = decrease(object.freckles_t),
+      id = object.freckles_t,
       opacity = convertToPercent(object.freckles_op)
     }
     object.freckles_t = nil
     object.freckles_op = nil
 
     standard.overlays.lipstick = object.lipsticks_t and {
-      id = 0,
-      sheetGrid = decrease(object.lipsticks_t),
+      id = object.eyeliners_t,
+      sheetGrid = 0,
       palette = object.lipsticks_id,
       tint0 = object.lipsticks_c1,
       tint1 = object.lipsticks_c2,
@@ -1538,21 +1533,21 @@ local function standardizeSkin(object)
     object.lipsticks_op = nil
 
     standard.overlays.moles = object.moles_t and {
-      id = decrease(object.moles_t),
+      id = object.moles_t,
       opacity = convertToPercent(object.moles_op)
     }
     object.moles_t = nil
     object.moles_op = nil
 
     standard.overlays.scar = object.scars_t and {
-      id = decrease(object.scars_t),
+      id = object.scars_t,
       opacity = convertToPercent(object.scars_op)
     }
     object.scars_t = nil
     object.scars_op = nil
 
     standard.overlays.spots = object.spots_t and {
-      id = decrease(object.spots_t),
+      id = object.spots_t,
       opacity = convertToPercent(object.spots_op)
     }
     object.spots_t = nil
@@ -1657,7 +1652,7 @@ local function standardizeSkin(object)
 
     standard.overlays = {}
     standard.overlays.ageing = object.ageing_t and {
-      id = decrease(object.ageing_t),
+      id = object.ageing_t,
       opacity = convertToPercent(object.ageing_op)
     }
     object.ageing_t = nil
@@ -1671,7 +1666,7 @@ local function standardizeSkin(object)
     object.beardstabble_op = nil
 
     standard.overlays.blush = object.blush_t and {
-      id = decrease(object.blush_t),
+      id = object.blush_t,
       palette = object.blush_id,
       tint0 = object.blush_c1,
       opacity = convertToPercent(object.blush_op)
@@ -1682,7 +1677,7 @@ local function standardizeSkin(object)
     object.blush_op = nil
 
     standard.overlays.eyebrow = object.eyebrows_t and (function()
-      local id = decrease(object.eyebrows_t)
+      local id = object.eyebrows_t
       local sexe = "m"
       if id > 15 then
         id = id - 15
@@ -1702,8 +1697,8 @@ local function standardizeSkin(object)
     object.eyebrows_op = nil
 
     standard.overlays.eyeliner = object.eyeliners_t and {
-      id = 0,
-      sheetGrid = decrease(object.eyeliners_t),
+      id = object.eyeliners_t,
+      sheetGrid = 0,
       palette = object.eyeliners_id,
       tint0 = object.eyeliners_c1,
       opacity = convertToPercent(object.eyeliners_op)
@@ -1714,8 +1709,8 @@ local function standardizeSkin(object)
     object.eyeliners_op = nil
 
     standard.overlays.eyeshadow = object.shadows_t and {
-      id = 0,
-      sheetGrid = decrease(object.shadows_t),
+      id = object.shadows_t,
+      sheetGrid = 0,
       palette = object.shadows_id,
       tint0 = object.shadows_c1,
       opacity = convertToPercent(object.shadows_op)
@@ -1726,15 +1721,15 @@ local function standardizeSkin(object)
     object.shadows_op = nil
 
     standard.overlays.freckles = object.freckles_t and {
-      id = decrease(object.freckles_t),
+      id = object.freckles_t,
       opacity = convertToPercent(object.freckles_op)
     }
     object.freckles_t = nil
     object.freckles_op = nil
 
     standard.overlays.lipstick = object.lipsticks_t and {
-      id = 0,
-      sheetGrid = decrease(object.lipsticks_t),
+      id = object.eyeliners_t,
+      sheetGrid = 0,
       palette = object.lipsticks_id,
       tint0 = object.lipsticks_c1,
       tint1 = object.lipsticks_c2,
@@ -1747,21 +1742,21 @@ local function standardizeSkin(object)
     object.lipsticks_op = nil
 
     standard.overlays.moles = object.moles_t and {
-      id = decrease(object.moles_t),
+      id = object.moles_t,
       opacity = convertToPercent(object.moles_op)
     }
     object.moles_t = nil
     object.moles_op = nil
 
     standard.overlays.scar = object.scars_t and {
-      id = decrease(object.scars_t),
+      id = object.scars_t,
       opacity = convertToPercent(object.scars_op)
     }
     object.scars_t = nil
     object.scars_op = nil
 
     standard.overlays.spots = object.spots_t and {
-      id = decrease(object.spots_t),
+      id = object.spots_t,
       opacity = convertToPercent(object.spots_op)
     }
     object.spots_t = nil


### PR DESCRIPTION
- [Updated]: function standardizeSkin. 
-- [Added]: Skin bridge for RedEM2023 @KadDarem this could honestly probably be updated on line 1359 to be "or jo.framework:is("RedEM2023") or jo.framework:is("RedEM")  as I mentioned in ticket, all 3 frameworks use the same layout for skin data.
- [Updated]: standard.hair, standard.beard checks to compare against hair dictionary (hairs.lua, hairs_list). -- This is effectively taking the same logic that redemrp_creator & rsg_appearance use. There's probably a cleaner way of doing this, and I'd be surprised if your hairdresser didn't already have a similar function, so consider updating it to your solution.
- [Added] standard.teethIndex check. If it's nil, set to 0 so it can be initialized.
- [Added] teethIndex to teethHash check. Basically checks to see if upstream data.teeth is being stored as a hash, rather than an index. If it is, then it will swap standard.teethIndex over to standard.teethHash so getTeethFromIndex won't break downstream

For additional context, see PR's that I've pulled for:

redemrp_creator: https://github.com/RedEM-RP/redemrp_creator/pull/19
rsg_appearance: https://github.com/Rexshack-RedM/rsg-appearance/pull/41