### PR TITLE
Fix error 'attempt to index a boolean value (local 'user')"

### DIFF
--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -73,6 +73,9 @@ end
 ---@return table (Return the player's identifiers <br> `identifiers.identifier` - Unique identifier of the player <br> `identifiers.charid` - Unique id of the player)
 function jo.framework:getUserIdentifiers(source)
   local user = jo.framework.UserClass:get(source)
+  if not user or type(user) ~= "table" then
+    return nil
+  end
   return user:getIdentifiers()
 end
 


### PR DESCRIPTION
attempt to index a boolean value (local 'user')

![image](https://github.com/user-attachments/assets/34f2c89e-642b-4f7f-a3ba-74dc7ea2df02)


The error occurs when a player disconnects during the server loading period.

This fix has been tested for days on my server and without any problems!