### PR TITLE
Fix: Wagon Storage Issue in RSG (version 1.0)

### DIFF
--- a/jo_libs/modules/framework-bridge/qbr/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/qbr/FrameworkClass.lua
@@ -74,6 +74,7 @@ function jo.framework:createInventory(invName, name, invConfig)
     name = name,
     invConfig = invConfig
   }
+  return true
 end
 
 ---@param invName string unique ID of the inventory

--- a/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
@@ -318,7 +318,7 @@ function jo.framework:createInventory(id, name, invConfig)
 end
 
 function jo.framework:openInventory(source, id)
-  local config = inventoriesCreated[id]
+  local config = inventoriesCreated[id].config
 
   TriggerClientEvent("jo_libs:client:openInventory", source, id, config)
   return

--- a/jo_libs/modules/framework-bridge/rsg/g_client.lua
+++ b/jo_libs/modules/framework-bridge/rsg/g_client.lua
@@ -4,6 +4,9 @@ RegisterNetEvent("rsg-clothes:ApplyClothes", function(clothes, ped, skin)
 end)
 
 RegisterNetEvent("jo_libs:client:openInventory", function(name, config)
-  TriggerServerEvent("inventory:server:OpenInventory", "stash", name, { maxweight = config.maxWeight, slots = config.maxSlots })
+  TriggerServerEvent("inventory:server:OpenInventory", "stash", name, {
+    maxweight = config.maxWeight,
+    slots = config.maxSlots
+  })
   TriggerEvent("inventory:client:SetCurrentStash", name)
 end)


### PR DESCRIPTION
This PR fixes an issue in the `jo_libs:client:openInventory` event where the max weight and slot count values were being read incorrectly. The previous implementation accessed `config.maxWeight` and `config.maxSlots` directly, which returned `nil` and caused the stash to open with invalid values unrelated to the wagon model.