### PR TITLE
feat(witness): add job-based witness alert module

### DIFF
--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -651,6 +651,31 @@ function jo.framework:mergeInventoriesConfiguration(...)
   return inventoryConfig
 end
 
+--- Retrieves all online player source IDs whose job matches one of the given jobs
+---@param jobs string[] (List of job names to filter by, e.g. `{ "police", "sheriff" }`)
+---@return integer[] (Array of matching source IDs)
+function jo.framework:getPlayersWithJobs(jobs)
+  local targets = {}
+  if not jobs or #jobs == 0 then return targets end
+
+  local jobSet = {}
+  for i = 1, #jobs do jobSet[jobs[i]] = true end
+
+  local players = GetPlayers()
+  for i = 1, #players do
+    local src = tonumber(players[i])
+    local user = self:getUser(src)
+    if user and type(user) == "table" then
+      local job = user:getJob()
+      if job and jobSet[job] then
+        targets[#targets + 1] = src
+      end
+    end
+  end
+
+  return targets
+end
+
 -- -----------
 -- END LOAD CUSTOM FUNCTIONS
 -- -----------

--- a/jo_libs/modules/witness/client.lua
+++ b/jo_libs/modules/witness/client.lua
@@ -1,0 +1,28 @@
+jo.require("notif")
+jo.require("blip")
+
+jo.createModule("witness")
+
+local activeBlips = {}
+
+jo.stopped(function()
+  for blip in pairs(activeBlips) do
+    if DoesBlipExist(blip) then RemoveBlip(blip) end
+  end
+  activeBlips = {}
+end)
+
+RegisterNetEvent("jo_libs:witness:alert", function(title, message, coords, blipDuration)
+  jo.notif.left(title, message, "menu_textures", "menu_icon_alert", "COLOR_RED", 10000)
+
+  local blip = jo.blip.create(coords, title, "blip_wanted_poster")
+  if not blip then return end
+
+  activeBlips[blip] = true
+
+  CreateThread(function()
+    Wait(blipDuration or 600000)
+    if DoesBlipExist(blip) then RemoveBlip(blip) end
+    activeBlips[blip] = nil
+  end)
+end)

--- a/jo_libs/modules/witness/server.lua
+++ b/jo_libs/modules/witness/server.lua
@@ -1,4 +1,5 @@
 jo.require("framework-bridge")
+jo.require("emit")
 
 jo.createModule("witness")
 
@@ -13,19 +14,15 @@ jo.createModule("witness")
 function jo.witness.report(jobs, title, message, coords, blipDuration)
   if not jobs or #jobs == 0 then return end
 
-  local jobSet = {}
-  for _, j in ipairs(jobs) do jobSet[j] = true end
+  local targets = jo.framework:getPlayersWithJobs(jobs)
+  if #targets == 0 then return end
 
-  local duration = blipDuration or 600000
-
-  for _, playerId in ipairs(GetPlayers()) do
-    local src = tonumber(playerId)
-    local user = jo.framework:getUser(src)
-    if user and type(user) == "table" then
-      local job = user:getJob()
-      if job and jobSet[job] then
-        TriggerClientEvent("jo_libs:witness:alert", src, title, message, coords, duration)
-      end
-    end
-  end
+  jo.emit.triggerClient(
+    "jo_libs:witness:alert",
+    targets,
+    title,
+    message,
+    coords,
+    blipDuration or 600000
+  )
 end

--- a/jo_libs/modules/witness/server.lua
+++ b/jo_libs/modules/witness/server.lua
@@ -1,0 +1,31 @@
+jo.require("framework-bridge")
+
+jo.createModule("witness")
+
+--- Broadcast a witness alert (notification + temporary map blip) to every online
+--- player whose job matches the given list. The client-side handler is registered
+--- automatically by `modules/witness/client.lua`.
+---@param jobs string[] List of job names allowed to receive the alert (e.g. `{ "police", "sheriff" }`)
+---@param title string Notification title (also used as blip label)
+---@param message string Notification body text
+---@param coords vector3 World position of the map blip
+---@param blipDuration? integer Blip lifetime in ms (default: `600000` = 10 minutes)
+function jo.witness.report(jobs, title, message, coords, blipDuration)
+  if not jobs or #jobs == 0 then return end
+
+  local jobSet = {}
+  for _, j in ipairs(jobs) do jobSet[j] = true end
+
+  local duration = blipDuration or 600000
+
+  for _, playerId in ipairs(GetPlayers()) do
+    local src = tonumber(playerId)
+    local user = jo.framework:getUser(src)
+    if user and type(user) == "table" then
+      local job = user:getJob()
+      if job and jobSet[job] then
+        TriggerClientEvent("jo_libs:witness:alert", src, title, message, coords, duration)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a new `witness` module that broadcasts a witness alert (left-side notification + temporary map blip) to every online player whose job matches a given list. Typical use cases: crime reports to `police`/`sheriff`, medical alerts to `ems`/`doctor`, fires to `firefighter`, etc.

The server-side heavy lifting (filtering players by job) lives inside `framework-bridge` as a reusable helper — the witness module itself is just the event-wiring layer on top.

## API

### Server
```lua
jo.witness.report(jobs, title, message, coords, blipDuration?)
-- jobs: string[]          -- e.g. { "police", "sheriff" }
-- title: string           -- notification title + blip label
-- message: string         -- notification body
-- coords: vector3         -- map blip position
-- blipDuration: integer?  -- blip lifetime in ms (default: 600000 = 10 min)
```

### Client
Handled automatically via the `jo_libs:witness:alert` net event — no direct API surface.

### New framework-bridge helper
```lua
jo.framework:getPlayersWithJobs(jobs) -- returns integer[] of matching source IDs
```
Iterates `GetPlayers()` with `for i = 1, #players do`, resolves each player's job via `self:getUser(src):getJob()`, and uses a Lua set (also built with a `for i` loop) for O(1) membership checks. Available to every module and script that depends on `framework-bridge`.

## Implementation notes
- `modules/framework-bridge/server.lua`: adds `jo.framework:getPlayersWithJobs(jobs)` (see above).
- `modules/witness/server.lua`: `jo.witness.report` now composes the event — it asks framework-bridge for the target list and fires it once via `jo.emit.triggerClient("jo_libs:witness:alert", targets, ...)`, so the msgpack payload is packed a single time instead of per-recipient.
- `modules/witness/client.lua`: unchanged — registers the net event, shows the left-side notification via `jo.notif.left`, spawns a `jo.blip.create(coords, title, "blip_wanted_poster")`, and removes the blip after `blipDuration` ms. `jo.stopped` removes any active witness blips on resource stop.
- Explicit dependencies declared at the top of each file: `jo.require("framework-bridge")` + `jo.require("emit")` (server), `jo.require("notif")` + `jo.require("blip")` (client).

## Event namespace
Alert event is `jo_libs:witness:alert` (namespaced to leave room for future witness-related events like `:clear` or `:ack`).

## fxmanifest
No changes required — the `modules/**/*client.lua` and `modules/**/*server.lua` globs pick the files up automatically. Consumers opt in with `jo_lib "witness"` in their resource manifest.

## Usage example
```lua
-- Server-side, after detecting a crime
jo.witness.report(
  { "police", "sheriff" },
  "Robbery in progress",
  "A player is robbing the Valentine bank",
  vector3(-323.4, 781.2, 117.3),
  5 * 60 * 1000  -- 5-minute blip
)
```