### PR TITLE
feat(webhook): add Discord webhook dispatcher module

### DIFF
--- a/jo_libs/modules/webhook/server.lua
+++ b/jo_libs/modules/webhook/server.lua
@@ -1,0 +1,138 @@
+jo.require("framework-bridge")
+
+jo.createModule("webhook")
+
+-- When nil, `dispatch` falls back to reading `Config.Webhook` and the global
+-- `SendScriptWebhook` from the consumer resource. Set explicitly via
+-- `jo.webhook.setConfig(...)` for a cleaner integration.
+local config = nil
+
+--- Configure the webhook backend explicitly.
+--- Call this once at startup (e.g. in your resource's server.lua) before
+--- invoking `jo.webhook.dispatch`. When omitted, the module falls back
+--- to `Config.Webhook` and the global `SendScriptWebhook` function.
+---@param opts table
+---| "type" # "discord"|"custom" — routing mode
+---| "url" # string? — Discord webhook URL (required when type = "discord")
+---| "customHandler" # fun(payload: table)? — called when type = "custom"
+function jo.webhook.setConfig(opts)
+  config = opts or {}
+end
+
+local function resolveConfig()
+  if config then return config end
+  if Config and Config.Webhook then
+    return {
+      type = Config.Webhook.type,
+      url = Config.Webhook.url,
+      customHandler = _G.SendScriptWebhook,
+    }
+  end
+end
+
+--- Dispatch a Discord-compatible payload using the active config.
+--- Routes to the Discord URL when `type = "discord"`, or to the custom
+--- handler when `type = "custom"`. Silently no-ops if no config is set
+--- and no fallback exists.
+---@param data table Discord webhook payload (e.g. `{ username, avatar_url, embeds }`)
+function jo.webhook.dispatch(data)
+  local cfg = resolveConfig()
+  if not cfg then return end
+  if cfg.type == "custom" then
+    if cfg.customHandler then cfg.customHandler(data) end
+    return
+  end
+  if not cfg.url or cfg.url == "" then return end
+  local ok, body = pcall(json.encode, data)
+  if not ok then return end
+  PerformHttpRequest(cfg.url, function() end, "POST", body, { ["Content-Type"] = "application/json" })
+end
+
+--- Build a Discord embed with a consistent footer (script name + timestamp)
+--- and an ISO-8601 timestamp.
+---@param opts table
+---| "title" # string? — Embed title
+---| "description" # string? — Embed description
+---| "color" # integer? — Embed color (default: `3066993` green)
+---| "fields" # table? — Embed fields array
+---| "script_name" # string? — Override footer resource name (default: current resource)
+---@return table embed
+function jo.webhook.buildEmbed(opts)
+  local script_name = opts.script_name or GetCurrentResourceName()
+  return {
+    title = opts.title or "",
+    description = opts.description or "",
+    color = opts.color or 3066993,
+    fields = opts.fields or {},
+    footer = { text = script_name .. " • " .. os.date("%d/%m/%Y %H:%M:%S") },
+    timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+  }
+end
+
+--- Return basic identity info for a player, useful as webhook embed fields.
+---@param source integer Server ID of the player
+---@return table info `{ name, serverId, steam, charId }`
+function jo.webhook.getPlayerInfo(source)
+  local info = {
+    name = GetPlayerName(source) or "Unknown",
+    serverId = tostring(source),
+    steam = "Unknown",
+    charId = "Unknown",
+  }
+
+  for _, id in ipairs(GetPlayerIdentifiers(source) or {}) do
+    if id:find("^steam:") then
+      info.steam = id
+      break
+    end
+  end
+
+  if jo.isModuleLoaded("framework-bridge", false) then
+    local user = jo.framework:getUser(source)
+    if type(user) == "table" then
+      local ids = user:getIdentifiers()
+      if ids then info.charId = tostring(ids.charid or "Unknown") end
+    end
+  end
+
+  return info
+end
+
+--- Build a ready-to-dispatch Discord payload with player identity fields
+--- (Player / Server ID / Steam) prepended to the embed fields.
+---@param source integer Server ID of the player
+---@param opts table
+---| "title" # string? — Embed title
+---| "description" # string? — Embed description
+---| "color" # integer? — Embed color
+---| "extra_fields" # table? — Additional embed fields appended after the identity fields
+---| "script_name" # string? — Override username/footer (default: current resource)
+---| "avatar_url" # string? — Webhook avatar URL
+---@return table payload
+function jo.webhook.buildPayload(source, opts)
+  local player = jo.webhook.getPlayerInfo(source)
+  local script_name = opts.script_name or GetCurrentResourceName()
+
+  local fields = {
+    { name = "Player",    value = player.name,     inline = true },
+    { name = "Server ID", value = player.serverId, inline = true },
+    { name = "Steam",     value = player.steam,    inline = true },
+  }
+  if opts.extra_fields then
+    for _, f in ipairs(opts.extra_fields) do fields[#fields + 1] = f end
+  end
+
+  return {
+    username = script_name,
+    avatar_url = opts.avatar_url or "",
+    embeds = {
+      jo.webhook.buildEmbed({
+        title = opts.title,
+        description = opts.description,
+        color = opts.color,
+        fields = fields,
+        script_name = script_name,
+      }),
+    },
+  }
+end

--- a/jo_libs/modules/webhook/server.lua
+++ b/jo_libs/modules/webhook/server.lua
@@ -1,5 +1,3 @@
-jo.require("framework-bridge")
-
 jo.createModule("webhook")
 
 -- When nil, `dispatch` falls back to reading `Config.Webhook` and the global
@@ -69,29 +67,25 @@ function jo.webhook.buildEmbed(opts)
   }
 end
 
---- Return basic identity info for a player, useful as webhook embed fields.
+--- Return basic identity info for a player using native FiveM APIs only.
+--- Extra identifiers (char ID, job, etc.) must be supplied by the caller
+--- via `opts.player` on `buildPayload`, so this module stays independent
+--- of the framework-bridge.
 ---@param source integer Server ID of the player
----@return table info `{ name, serverId, steam, charId }`
+---@return table info `{ name, serverId, steam }`
 function jo.webhook.getPlayerInfo(source)
   local info = {
     name = GetPlayerName(source) or "Unknown",
     serverId = tostring(source),
     steam = "Unknown",
-    charId = "Unknown",
   }
 
-  for _, id in ipairs(GetPlayerIdentifiers(source) or {}) do
+  local identifiers = GetPlayerIdentifiers(source) or {}
+  for i = 1, #identifiers do
+    local id = identifiers[i]
     if id:find("^steam:") then
       info.steam = id
       break
-    end
-  end
-
-  if jo.isModuleLoaded("framework-bridge", false) then
-    local user = jo.framework:getUser(source)
-    if type(user) == "table" then
-      local ids = user:getIdentifiers()
-      if ids then info.charId = tostring(ids.charid or "Unknown") end
     end
   end
 
@@ -99,27 +93,31 @@ function jo.webhook.getPlayerInfo(source)
 end
 
 --- Build a ready-to-dispatch Discord payload with player identity fields
---- (Player / Server ID / Steam) prepended to the embed fields.
+--- prepended to the embed fields. When `opts.player` is provided it is used
+--- verbatim, so callers can inject framework-specific fields like `charId`
+--- without creating a dependency from this module on framework-bridge.
 ---@param source integer Server ID of the player
 ---@param opts table
 ---| "title" # string? — Embed title
 ---| "description" # string? — Embed description
 ---| "color" # integer? — Embed color
+---| "player" # table? — `{ name?, serverId?, steam?, charId?, ... }` overrides the native lookup
 ---| "extra_fields" # table? — Additional embed fields appended after the identity fields
 ---| "script_name" # string? — Override username/footer (default: current resource)
 ---| "avatar_url" # string? — Webhook avatar URL
 ---@return table payload
 function jo.webhook.buildPayload(source, opts)
-  local player = jo.webhook.getPlayerInfo(source)
+  local player = opts.player or jo.webhook.getPlayerInfo(source)
   local script_name = opts.script_name or GetCurrentResourceName()
 
-  local fields = {
-    { name = "Player",    value = player.name,     inline = true },
-    { name = "Server ID", value = player.serverId, inline = true },
-    { name = "Steam",     value = player.steam,    inline = true },
-  }
+  local fields = {}
+  if player.name     then fields[#fields + 1] = { name = "Player",    value = tostring(player.name),     inline = true } end
+  if player.serverId then fields[#fields + 1] = { name = "Server ID", value = tostring(player.serverId), inline = true } end
+  if player.steam    then fields[#fields + 1] = { name = "Steam",     value = tostring(player.steam),    inline = true } end
+  if player.charId   then fields[#fields + 1] = { name = "Char ID",   value = tostring(player.charId),   inline = true } end
+
   if opts.extra_fields then
-    for _, f in ipairs(opts.extra_fields) do fields[#fields + 1] = f end
+    for i = 1, #opts.extra_fields do fields[#fields + 1] = opts.extra_fields[i] end
   end
 
   return {


### PR DESCRIPTION
## Summary
Adds a server-side `webhook` module to centralise Discord-compatible webhook dispatch. Most RedM scripts re-implement the same four pieces of boilerplate — reading a config, building a Discord embed, injecting player identity, and POSTing the payload. This module provides all four behind a single `jo.webhook.*` API.

**No dependency on `framework-bridge`.** Player identity is resolved with native FiveM APIs (`GetPlayerName`, `GetPlayerIdentifiers`); anything framework-specific (e.g. `charId`) is supplied by the caller via `opts.player` so scripts that don't use framework-bridge can still use this module, and vice-versa.

## API

### Configuration
```lua
-- Explicit (preferred)
jo.webhook.setConfig({
  type = "discord",              -- "discord" | "custom"
  url = "https://discord.com/api/webhooks/...",
  customHandler = function(payload) ... end,   -- used when type = "custom"
})

-- Fallback: if setConfig() is never called, dispatch() reads
-- `Config.Webhook.type`, `Config.Webhook.url` and the global
-- `SendScriptWebhook` from the consumer resource. This keeps
-- existing scripts that follow that convention working with zero
-- changes.
```

### Dispatch
```lua
jo.webhook.dispatch(payload)                 -- raw payload passthrough
jo.webhook.buildEmbed(options)               -- standard embed + footer
jo.webhook.getPlayerInfo(source)             -- { name, serverId, steam }  (native-only)
jo.webhook.buildPayload(source, options)     -- complete payload; options.player overrides native lookup
```

## Implementation notes
- Single file: `jo_libs/modules/webhook/server.lua`.
- `setConfig` stores config in module-local state; no reliance on consumer globals when set.
- When `type = "custom"`, `dispatch` defers to `customHandler(payload)` — useful for non-Discord backends (e.g. an internal logging service).
- `getPlayerInfo(source)` returns only what native FiveM exposes: `{ name, serverId, steam }`. No framework calls.
- `buildPayload(source, opts)` uses `opts.player` verbatim when provided, otherwise falls back to `getPlayerInfo(source)`. Only populated fields are rendered as embed fields, so projections stay clean for consoles that don't expose Steam, characters without a `charId`, etc.
- `buildEmbed` adds a consistent footer (`<script> • DD/MM/YYYY HH:MM:SS`) and an ISO-8601 timestamp for Discord.

## fxmanifest
No changes required — the `modules/**/*server.lua` glob picks the new file up automatically. Consumers opt in with `jo_lib "webhook"` in their resource manifest.

## Usage example
```lua
-- Startup
jo.webhook.setConfig({ type = "discord", url = GetConvar("my_script:webhook", "") })

-- On an event — with framework-bridge (caller injects charId)
local ids = jo.framework:getUser(source):getIdentifiers()
jo.webhook.dispatch(jo.webhook.buildPayload(source, {
  title = "Crate looted",
  description = "Player looted a supply crate",
  color = 16766720,  -- orange
  player = {
    name     = GetPlayerName(source),
    serverId = tostring(source),
    charId   = tostring(ids.charid),
  },
  extra_fields = {
    { name = "Item", value = "medkit x2", inline = true },
    { name = "Zone", value = "Valentine",  inline = true },
  },
}))

-- On an event — without framework-bridge (native identity only)
jo.webhook.dispatch(jo.webhook.buildPayload(source, {
  title = "Player connected",
}))
```