### PR TITLE
feat(version-checker): allow per-resource config via fxmanifest metadata

### DIFF
--- a/jo_libs/modules/version-checker/server.lua
+++ b/jo_libs/modules/version-checker/server.lua
@@ -1,5 +1,7 @@
 -------------
--- ONLY FOR Jump On Studios Scripts !
+-- Generic version-checker module. Defaults route to the JUMP ON Studios
+-- release API and download portal; third-party script authors can override
+-- any field via `jo.versionChecker.setConfig(...)` before `jo.ready` fires.
 -------------
 
 jo.require("string")
@@ -29,6 +31,74 @@ local function urlencode(str)
   end
   return str
 end
+
+-------------
+-- CONFIG
+-------------
+
+local defaultConfig = {
+  apiUrl = "https://jumpon-studios.com/api/checkScriptVersion?package=%d",
+  downloadUrl = function(packageID)
+    if packageID < 1000 then
+      return "https://github.com/Jump-On-Studios"
+    end
+    return "https://portal.cfx.re/assets/granted-assets"
+  end,
+  brandingName = "jumpon-studios.com",
+  versionKey = "version",
+  bodyKey = "body",
+  stripPrefix = true,
+}
+
+local config = nil
+
+--- Configure the backend used by `jo.versionChecker.checkUpdate()`.
+--- Call this before `jo.ready` fires (typically at the top of your
+--- resource's server.lua). Omitted fields keep the JUMP ON Studios
+--- defaults, so third-party scripts can override only what they need.
+---@param opts table
+---| "apiUrl" # string? — URL template, `%d` is replaced by the resource's `package_id`
+---| "downloadUrl" # string|fun(packageID: integer):string? — static URL or resolver
+---| "brandingName" # string? — shown inside the footer line
+---| "versionKey" # string? — JSON key holding the latest version (default: `"version"`)
+---| "bodyKey" # string? — JSON key holding the release notes (default: `"body"`)
+---| "stripPrefix" # boolean? — strip a leading `v` from the API's version string (default: `true`)
+function jo.versionChecker.setConfig(opts)
+  config = opts or {}
+end
+
+local function getConfig(key)
+  if config and config[key] ~= nil then return config[key] end
+  return defaultConfig[key]
+end
+
+local function resolveDownloadUrl(packageID)
+  local downloadUrl = getConfig("downloadUrl")
+  if type(downloadUrl) == "function" then
+    return downloadUrl(packageID)
+  end
+  return downloadUrl
+end
+
+local function buildFooter(brandingName)
+  -- Preserve the original JUMP ON Studios footer byte-for-byte when the
+  -- default branding is used, so no existing script's console diff changes.
+  if brandingName == defaultConfig.brandingName then
+    return "└───────────────── jumpon-studios.com ──────────────┘"
+  end
+  -- Generic: keep the same inner width (51 cols) and center the branding.
+  local text = " " .. brandingName .. " "
+  local innerWidth = 51
+  local hyphens = innerWidth - #text
+  if hyphens < 0 then hyphens = 0 end
+  local left = math.floor(hyphens / 2)
+  local right = hyphens - left
+  return ("└%s%s%s┘"):format(string.rep("─", left), text, string.rep("─", right))
+end
+
+-------------
+-- PUBLIC API
+-------------
 
 function jo.versionChecker.GetScriptVersion()
   return GetResourceMetadata(GetCurrentResourceName(), "version", 0) or 1
@@ -62,7 +132,13 @@ function jo.versionChecker.checkUpdate()
     --   framework = urlencode(jo.framework:get())
     -- end
 
-    local link = ("https://jumpon-studios.com/api/checkScriptVersion?package=%d"):format(packageID)
+    local apiUrl = getConfig("apiUrl")
+    local versionKey = getConfig("versionKey")
+    local bodyKey = getConfig("bodyKey")
+    local stripPrefix = getConfig("stripPrefix")
+    local brandingName = getConfig("brandingName")
+
+    local link = apiUrl:format(packageID)
     PerformHttpRequest(link, function(errorCode, resultData, resultHeaders, errorData)
       Wait(1000)
       if killed then return end
@@ -70,23 +146,24 @@ function jo.versionChecker.checkUpdate()
         return print("^3" .. myResource .. ": version checker API is offline. Impossible to check your version.^0")
       end
       resultData = json.decode(resultData)
-      if not resultData.version then
+      local remoteVersion = resultData and resultData[versionKey]
+      if not remoteVersion then
         return print("^3" .. myResource .. ": error in the format of version checker. Impossible to check your version.^0")
       end
-      local lastVersion = resultData.version:sub(2)
+      local lastVersion = stripPrefix and remoteVersion:sub(2) or remoteVersion
       if currentVersion:compareVersionWith(lastVersion) >= 0 then
         return print(("^3%s: \x1b[92mUp to date - Version %s^0"):format(myResource, currentVersion))
       end
       print("^3┌───────────────────────────────────────────────────┐^0")
       print("")
-      print("^3" .. myResource .. ": ^5 Update found : Version " .. resultData.version .. "^0")
+      print("^3" .. myResource .. ": ^5 Update found : Version " .. remoteVersion .. "^0")
       print("^3" .. myResource .. ": ^1 Your Version : Version v" .. currentVersion .. "^0")
-      print(("^3Download it on ^0%s"):format(packageID < 1000 and "https://github.com/Jump-On-Studios" or "https://portal.cfx.re/assets/granted-assets"))
+      print(("^3Download it on ^0%s"):format(resolveDownloadUrl(packageID)))
       print("")
-      print("^3 Description of " .. resultData.version .. ":^0")
-      print(resultData.body)
+      print("^3 Description of " .. remoteVersion .. ":^0")
+      print(resultData[bodyKey])
       print("")
-      print("^3└───────────────── jumpon-studios.com ──────────────┘^0")
+      print("^3" .. buildFooter(brandingName) .. "^0")
     end)
 
     local dependencies = GetResourceMetadata(myResource, "dependencies_version_min", 0)

--- a/jo_libs/modules/version-checker/server.lua
+++ b/jo_libs/modules/version-checker/server.lua
@@ -1,7 +1,15 @@
 -------------
 -- Generic version-checker module. Defaults route to the JUMP ON Studios
 -- release API and download portal; third-party script authors can override
--- any field via `jo.versionChecker.setConfig(...)` before `jo.ready` fires.
+-- any field by declaring metadata in their own `fxmanifest.lua`:
+--
+--   author "twinded.ca"                                     -- footer branding
+--   version "1.0.0"                                         -- standard FiveM
+--   versionEndpoint "https://your.domain/checkVersion?package=%d"
+--   downloadUrl "https://your.domain/download"
+--
+-- All per-resource keys are optional; anything left out falls back to the
+-- JUMP ON Studios defaults, so existing scripts keep their current behaviour.
 -------------
 
 jo.require("string")
@@ -50,30 +58,27 @@ local defaultConfig = {
   stripPrefix = true,
 }
 
-local config = nil
+-- Maps internal config keys to the fxmanifest metadata keys that override them.
+-- Keys not listed here are not user-configurable from the fxmanifest.
+local metadataKeys = {
+  apiUrl = "versionEndpoint",
+  downloadUrl = "downloadUrl",
+  brandingName = "author",
+}
 
---- Configure the backend used by `jo.versionChecker.checkUpdate()`.
---- Call this before `jo.ready` fires (typically at the top of your
---- resource's server.lua). Omitted fields keep the JUMP ON Studios
---- defaults, so third-party scripts can override only what they need.
----@param opts table
----| "apiUrl" # string? — URL template, `%d` is replaced by the resource's `package_id`
----| "downloadUrl" # string|fun(packageID: integer):string? — static URL or resolver
----| "brandingName" # string? — shown inside the footer line
----| "versionKey" # string? — JSON key holding the latest version (default: `"version"`)
----| "bodyKey" # string? — JSON key holding the release notes (default: `"body"`)
----| "stripPrefix" # boolean? — strip a leading `v` from the API's version string (default: `true`)
-function jo.versionChecker.setConfig(opts)
-  config = opts or {}
-end
-
-local function getConfig(key)
-  if config and config[key] ~= nil then return config[key] end
+local function getConfig(resource, key)
+  local metaKey = metadataKeys[key]
+  if metaKey then
+    local value = GetResourceMetadata(resource, metaKey, 0)
+    if value and value ~= "" then
+      return value
+    end
+  end
   return defaultConfig[key]
 end
 
-local function resolveDownloadUrl(packageID)
-  local downloadUrl = getConfig("downloadUrl")
+local function resolveDownloadUrl(resource, packageID)
+  local downloadUrl = getConfig(resource, "downloadUrl")
   if type(downloadUrl) == "function" then
     return downloadUrl(packageID)
   end
@@ -132,11 +137,11 @@ function jo.versionChecker.checkUpdate()
     --   framework = urlencode(jo.framework:get())
     -- end
 
-    local apiUrl = getConfig("apiUrl")
-    local versionKey = getConfig("versionKey")
-    local bodyKey = getConfig("bodyKey")
-    local stripPrefix = getConfig("stripPrefix")
-    local brandingName = getConfig("brandingName")
+    local apiUrl = getConfig(myResource, "apiUrl")
+    local versionKey = getConfig(myResource, "versionKey")
+    local bodyKey = getConfig(myResource, "bodyKey")
+    local stripPrefix = getConfig(myResource, "stripPrefix")
+    local brandingName = getConfig(myResource, "brandingName")
 
     local link = apiUrl:format(packageID)
     PerformHttpRequest(link, function(errorCode, resultData, resultHeaders, errorData)
@@ -158,7 +163,7 @@ function jo.versionChecker.checkUpdate()
       print("")
       print("^3" .. myResource .. ": ^5 Update found : Version " .. remoteVersion .. "^0")
       print("^3" .. myResource .. ": ^1 Your Version : Version v" .. currentVersion .. "^0")
-      print(("^3Download it on ^0%s"):format(resolveDownloadUrl(packageID)))
+      print(("^3Download it on ^0%s"):format(resolveDownloadUrl(myResource, packageID)))
       print("")
       print("^3 Description of " .. remoteVersion .. ":^0")
       print(resultData[bodyKey])


### PR DESCRIPTION
## Summary
Opens up `version-checker` so any script author can plug their own release API, download URL, and footer branding into it — **per resource, straight from each `fxmanifest.lua`** — without losing the current default behaviour for JUMP ON Studios scripts.

Motivation: the module's API URL (`jumpon-studios.com/api/checkScriptVersion`), download URLs (`github.com/Jump-On-Studios` / `portal.cfx.re/assets/granted-assets`) and footer text are currently hardcoded. Third-party script authors (myself included, for the Twinded RedM scripts) have to fork the module to reuse it on their own release channel.

## What changes
Each consumer resource can override any of the following in its own `fxmanifest.lua`:

| fxmanifest key     | Overrides         | Default                                                           |
|--------------------|-------------------|-------------------------------------------------------------------|
| `author`           | `brandingName`    | `jumpon-studios.com`                                              |
| `versionEndpoint`  | `apiUrl`          | `https://jumpon-studios.com/api/checkScriptVersion?package=%d`    |
| `downloadUrl`      | `downloadUrl`     | `package_id < 1000` → `github.com/Jump-On-Studios`, else CFX portal |

Non-overridable internals (kept as Lua defaults in the module) remain:
- `versionKey` = `"version"`
- `bodyKey` = `"body"`
- `stripPrefix` = `true` (strips the leading `v` from the API's version string)

Under the hood:
- Drops the previous `jo.versionChecker.setConfig(opts)` — configuration now lives in the manifest, which is already the source of truth for `version` and `package_id`.
- `getConfig(resource, key)` looks up the corresponding `GetResourceMetadata(resource, key, 0)` and falls back to the JUMP ON defaults when undeclared (or empty).
- `resolveDownloadUrl(resource, packageID)` takes the resource name so the lookup targets the right manifest.
- The footer preserves the original `└───────────────── jumpon-studios.com ──────────────┘` byte-for-byte when the default branding is in effect, so no console diff appears for scripts that leave `author` untouched relative to the default.

## Backward compatibility
- JUMP ON Studios scripts: **zero changes required** if their `fxmanifest.lua` does not declare `author` / `versionEndpoint` / `downloadUrl`. Defaults apply, behaviour unchanged.
- If a JUMP ON manifest already declares `author "Jump On Studios"`, the footer will switch from `jumpon-studios.com` to `Jump On Studios`. That's a cosmetic one-liner — happy to adjust (e.g. swap `author` → a dedicated `brandingName` metadata key) if you'd rather keep the footer identical across the existing catalog. Let me know which approach you prefer.
- `jo_libs:kill:resource` event handler, `StopAddon` export, `GetScriptVersion` function, and the `jo.ready(checkUpdate)` auto-call are all untouched.

## Usage for third parties
```lua
-- In the consumer's fxmanifest.lua
author "twinded.ca"
version "1.0.0"
versionEndpoint "https://twinded.ca/api/checkScriptVersion?package=%d"
downloadUrl "https://portal.cfx.re/assets/granted-assets"
```

No code changes needed on the consumer side — `jo.ready(checkUpdate)` still fires automatically.