### PR TITLE
fix(rsg): validate usable items from shared config and preserve image…

### DIFF
--- a/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
@@ -289,8 +289,8 @@ function jo.framework:registerUseItem(item, closeAfterUsed, callback)
     callback = closeAfterUsed
     closeAfterUsed = true
   end
-  local isAdded = RSGCore.Functions.AddItem(item, nil)
-  if isAdded then
+  local itemExists = RSGCore.Shared.Items[item] ~= nil
+  if not itemExists then
     return eprint(item .. " < item does not exist in the core configuration")
   end
   RSGCore.Functions.CreateUseableItem(item, function(source, data)

--- a/jo_libs/modules/framework-bridge/rsg_2/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rsg_2/FrameworkClass.lua
@@ -20,8 +20,8 @@ function jo.framework:registerUseItem(item, closeAfterUsed, callback)
     callback = closeAfterUsed
     closeAfterUsed = true
   end
-  local isAdded = RSGCore.Functions.AddItem(item, nil)
-  if isAdded then
+  local itemExists = RSGCore.Shared.Items[item] ~= nil
+  if not itemExists then
     return eprint(item .. " < item does not exist in the core configuration")
   end
   RSGCore.Functions.CreateUseableItem(item, function(source, data)

--- a/jo_libs/modules/framework-bridge/rsg_2/g_shared.lua
+++ b/jo_libs/modules/framework-bridge/rsg_2/g_shared.lua
@@ -5,12 +5,16 @@ function jo.framework:getInventoryItems()
   local itemsRSG = self.core.Shared.Items
   local items = {}
   for id, item in pairs(itemsRSG) do
+    local image = item.image or id
+    if not image:match("%.%w+$") then
+      image = image .. ".png"
+    end
     items[id] = {
       item = id,
       label = item.label,
       type = item.type,
       description = item.description,
-      image = "nui://rsg_inventory/html/images/" .. item.image .. ".png"
+      image = "nui://rsg_inventory/html/images/" .. image
     }
   end
   return items


### PR DESCRIPTION
## Summary
Fixes RSG item validation and prevents duplicate image extensions in inventory item data.
## Changes
- Validate usable items against `RSGCore.Shared.Items`
- Stop using `AddItem()` as an existence check
- Preserve existing image extensions in RSG V2 item definitions
## Notes
Improves compatibility with standard RSG item definitions. No breaking changes expected.
