### PR TITLE
fix(framework-bridge): centralize character selection callbacks

### DIFF
--- a/jo_libs/modules/framework-bridge/_default/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/_default/FrameworkClass.lua
@@ -388,12 +388,6 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
---- Callback when a character is selected
---- @param cb function (The callback function triggered when the character is selected)
-function jo.framework:onCharacterSelected(cb)
-  return false
-end
-
 -- Listener for item removed of the player inventory
 RegisterNetEvent("event_item_removed", function(source, item, quantity, meta)
   jo.framework:fireListenerItemRemoved(source, item, quantity, meta, "dropped")

--- a/jo_libs/modules/framework-bridge/frp/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/frp/FrameworkClass.lua
@@ -279,7 +279,3 @@ end
 function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   -- #TODO
 end
-
-function jo.framework:onCharacterSelected(cb)
-  -- #TODO
-end

--- a/jo_libs/modules/framework-bridge/qbr/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/qbr/FrameworkClass.lua
@@ -232,10 +232,8 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("qbr-multicharacter:server:loadUserData", function()
-    local source = source
-    Wait(1000)
-    cb(source)
-  end)
-end
+AddEventHandler("qbr-multicharacter:server:loadUserData", function()
+  local source = source
+  Wait(1000)
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/qr/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/qr/FrameworkClass.lua
@@ -185,10 +185,8 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("qr-multicharacter:server:loadUserData", function()
-    local source = source
-    Wait(1000)
-    cb(source)
-  end)
-end
+AddEventHandler("qr-multicharacter:server:loadUserData", function()
+  local source = source
+  Wait(1000)
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/redemrp_2023/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/redemrp_2023/FrameworkClass.lua
@@ -982,10 +982,7 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("redemrp:selectCharacter", function()
-    local source = source
-    Wait(1000)
-    cb(source)
-  end)
-end
+RegisterNetEvent("jo_libs:server:onCharacterSelected", function(isNew)
+  local source = source
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/redemrp_2023/g_client.lua
+++ b/jo_libs/modules/framework-bridge/redemrp_2023/g_client.lua
@@ -17,3 +17,8 @@ RegisterNetEvent("RedEM:client:ApplySkin", function(skin, ped, clothes)
   ped = ped or PlayerPedId()
   TriggerServerEvent("jo_libs:server:applySkinAndClothes", ped, skin, clothes)
 end)
+
+
+RegisterNetEvent("redemrp_charselect:client:FinishSelection", function(new)
+  TriggerServerEvent("jo_libs:server:onCharacterSelected", new)
+end)

--- a/jo_libs/modules/framework-bridge/redemrp_old/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/redemrp_old/FrameworkClass.lua
@@ -204,10 +204,8 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("redemrp:selectCharacter", function()
-    local source = source
-    Wait(1000)
-    cb(source)
-  end)
-end
+AddEventHandler("redemrp:selectCharacter", function()
+  local source = source
+  Wait(1000)
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/rpx/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rpx/FrameworkClass.lua
@@ -206,9 +206,7 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   return {}
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("SERVER:MultiCharacter:SelectCharacter", function()
-    local source = source
-    cb(source)
-  end)
-end
+AddEventHandler("SERVER:MultiCharacter:SelectCharacter", function()
+  local source = source
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
@@ -1069,10 +1069,7 @@ end
 -------------
 
 
-function jo.framework:onCharacterSelected(cb)
-  RegisterNetEvent("RSGCore:Server:OnPlayerLoaded")
-  AddEventHandler("RSGCore:Server:OnPlayerLoaded", function()
-    local source = source
-    cb(source)
-  end)
-end
+RegisterNetEvent("jo_libs:server:onCharacterSelected", function(isNew)
+  local source = source
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/rsg/FrameworkClass.lua
@@ -1069,7 +1069,26 @@ end
 -------------
 
 
-RegisterNetEvent("jo_libs:server:onCharacterSelected", function(isNew)
+
+local pendingCharacterSelection = {}
+
+-- New character event
+RegisterNetEvent("rsg-multicharacter:server:createCharacter", function()
   local source = source
-  ExecCharacterSelectedCallback(source, isNew)
+  pendingCharacterSelection[source] = true
+end)
+
+-- Existing character event
+RegisterNetEvent("rsg-multicharacter:server:loadUserData", function()
+  local source = source
+  pendingCharacterSelection[source] = false
+end)
+
+RegisterNetEvent("RSGCore:Server:OnPlayerLoaded", function()
+  local source = source
+  ExecCharacterSelectedCallback(source, pendingCharacterSelection[source])
+end)
+
+AddEventHandler("playerDropped", function(source)
+  pendingCharacterSelection[source] = nil
 end)

--- a/jo_libs/modules/framework-bridge/rsg/g_client.lua
+++ b/jo_libs/modules/framework-bridge/rsg/g_client.lua
@@ -10,3 +10,7 @@ RegisterNetEvent("jo_libs:client:openInventory", function(name, config)
   })
   TriggerEvent("inventory:client:SetCurrentStash", name)
 end)
+
+RegisterNetEvent("rsg-spawn:client:setupSpawnUI", function(_cData, new)
+  TriggerServerEvent("jo_libs:server:onCharacterSelected", new)
+end)

--- a/jo_libs/modules/framework-bridge/rsg/g_client.lua
+++ b/jo_libs/modules/framework-bridge/rsg/g_client.lua
@@ -10,7 +10,3 @@ RegisterNetEvent("jo_libs:client:openInventory", function(name, config)
   })
   TriggerEvent("inventory:client:SetCurrentStash", name)
 end)
-
-RegisterNetEvent("rsg-spawn:client:setupSpawnUI", function(_cData, new)
-  TriggerServerEvent("jo_libs:server:onCharacterSelected", new)
-end)

--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -570,7 +570,7 @@ function ExecCharacterSelectedCallback(source, isNew)
 end
 
 --- Callback when a character is selected
---- @param cb function (The callback function triggered when the character is selected)
+--- @param cb function (The callback function triggered when the character is selected, contains (source:integer, isNew:boolean))
 function jo.framework:onCharacterSelected(cb)
   table.insert(charSelectedCallbacks, cb)
 end

--- a/jo_libs/modules/framework-bridge/server.lua
+++ b/jo_libs/modules/framework-bridge/server.lua
@@ -13,6 +13,9 @@ jo.framework.UserClass = {}
 jo.framework:loadFile("UserClass")
 jo.framework:loadFile("FrameworkClass")
 
+
+
+
 -- -----------
 -- END LOAD FRAMEWORK
 -- -----------
@@ -89,6 +92,7 @@ function jo.framework:getUserIdentifiers(source)
   end
   return user:getIdentifiers()
 end
+
 jo.callback.register(jo.resourceName .. ":server:framework:getPlayerIdentifiers", function(source, playerId)
   return jo.framework:getUserIdentifiers(playerId or source)
 end)
@@ -556,6 +560,21 @@ function jo.framework:updateUserSkin(...)
   self:updateUserSkinInternal(source, skin, overwrite)
 end
 
+local charSelectedCallbacks = {}
+
+function ExecCharacterSelectedCallback(source, isNew)
+  isNew = GetValue(isNew, false)
+  for i = 1, #charSelectedCallbacks do
+    charSelectedCallbacks[i](source, isNew)
+  end
+end
+
+--- Callback when a character is selected
+--- @param cb function (The callback function triggered when the character is selected)
+function jo.framework:onCharacterSelected(cb)
+  table.insert(charSelectedCallbacks, cb)
+end
+
 -- -----------
 -- END POWER UP FUNCTIONS
 -- -----------
@@ -596,6 +615,8 @@ end
 jo.framework:onCharacterSelected(function(source)
   addIdentifiersLink(source)
 end)
+
+
 
 CreateThread(function()
   local players = GetPlayers()

--- a/jo_libs/modules/framework-bridge/tpzcore/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/tpzcore/FrameworkClass.lua
@@ -103,7 +103,7 @@ function jo.framework:openInventory(source, invName, header)
     header = "Storage"
   end
 
-  TriggerClientEvent('tpz_inventory:openInventoryContainerByName', _source, invName, header)
+  TriggerClientEvent("tpz_inventory:openInventoryContainerByName", _source, invName, header)
 end
 
 --- Adds a specific item to a custom inventory with optional metadata and wait parameter
@@ -453,10 +453,6 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
 
 end
 
---- Callback when a character is selected
---- @param cb function (The callback function triggered when the character is selected)
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("tpz_core:isPlayerReady", function(source)
-    cb(source)
-  end)
-end
+AddEventHandler("tpz_core:isPlayerReady", function(source)
+  ExecCharacterSelectedCallback(source, isNew)
+end)

--- a/jo_libs/modules/framework-bridge/vorp/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/vorp/FrameworkClass.lua
@@ -1318,14 +1318,13 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   end)
 end
 
+-- Existing character event
 RegisterNetEvent("vorp_CharSelectedCharacter", function(_charid)
   local source = source
-  log("Existing character selected", source, _charid)
   ExecCharacterSelectedCallback(source, false)
 end)
 
--- New character
+-- New character event
 RegisterNetEvent("vorp_NewCharacter", function(source)
-  log("New character created", source)
   ExecCharacterSelectedCallback(source, true)
 end)

--- a/jo_libs/modules/framework-bridge/vorp/FrameworkClass.lua
+++ b/jo_libs/modules/framework-bridge/vorp/FrameworkClass.lua
@@ -1318,8 +1318,14 @@ function jo.framework:createUser(source, data, spawnCoordinate, isDead)
   end)
 end
 
-function jo.framework:onCharacterSelected(cb)
-  AddEventHandler("vorp:SelectedCharacter", function(source)
-    cb(source)
-  end)
-end
+RegisterNetEvent("vorp_CharSelectedCharacter", function(_charid)
+  local source = source
+  log("Existing character selected", source, _charid)
+  ExecCharacterSelectedCallback(source, false)
+end)
+
+-- New character
+RegisterNetEvent("vorp_NewCharacter", function(source)
+  log("New character created", source)
+  ExecCharacterSelectedCallback(source, true)
+end)


### PR DESCRIPTION


### Summary

- Centralizes `onCharacterSelected` callback registration in the shared framework bridge server.
- Routes framework-specific character selection events through `ExecCharacterSelectedCallback`.
- Adds support for passing `isNew` character state where the framework exposes it.
- Updates RedEMRP 2023 and RSG client events to notify the shared server callback flow.

### Notes

This aligns character selection handling across supported framework bridges and avoids each framework redefining `jo.framework:onCharacterSelected`.
