### PR TITLE
fix(input): callback mode crashes in jo.input.nui

### DIFF
--- a/jo_libs/modules/input/client.lua
+++ b/jo_libs/modules/input/client.lua
@@ -52,7 +52,7 @@ function jo.input.nui(options, cb)
     SetNuiFocusKeepInput(keepInput)
     nuiOpened = false
   end
-  nuiResult = cb or promise.new()
+  nuiResult = promise.new()
   SendNUIMessage({
     messageTargetUiName = "jo_input",
     event = "newInput",


### PR DESCRIPTION
The callback version of jo.input.nui() currently crashes.

Current implementation:

`nuiResult = cb or promise.new()`

When a callback is supplied, nuiResult becomes a function.

Later, the NUI callback executes:

`nuiResult:resolve(data)`

which raises:

    attempt to index a function value

The callback is already invoked after Await(), so storing it in nuiResult is unnecessary.

This change ensures nuiResult is always a promise and fixes callback-based usage.