### PR TITLE
feat(framework): add `setJob` function

### DIFF
--- a/jo_libs/modules/framework-bridge/cores/_default/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/_default/server.lua
@@ -58,6 +58,14 @@ function jo.framework.UserClass:getJobGrade()
   return 0
 end
 
+--- Sets the current job assigned to a player
+---@param job string (The name of the job)
+---@param grade number (The grade of the job)
+---@return boolean (If job assignment was successful)
+function jo.framework.UserClass:setJob(job, grade)
+  return false
+end
+
 --- Returns the roleplay name (first and last name) of the player
 ---@return string (Returns the formatted first and last name of the player)
 function jo.framework.UserClass:getRPName()

--- a/jo_libs/modules/framework-bridge/cores/frp_core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/frp_core/server.lua
@@ -105,6 +105,10 @@ function jo.framework.UserClass:getJobGrade()
   return 0
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return false
+end
+
 ---@return string name player's name
 function jo.framework.UserClass:getRPName()
   local User = self.data

--- a/jo_libs/modules/framework-bridge/cores/qbr_core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/qbr_core/server.lua
@@ -82,6 +82,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.PlayerData.job.grade.level
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.Functions.SetJob(job, grade)
+end
+
 ---@return string name player's name
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.PlayerData.charinfo.firstname, self.data.PlayerData.charinfo.lastname)

--- a/jo_libs/modules/framework-bridge/cores/qr-core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/qr-core/server.lua
@@ -84,6 +84,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.job.grade.level
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.Functions.SetJob(job, grade)
+end
+
 ---@return string name player's name
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.PlayerData.charinfo.firstname, self.data.PlayerData.charinfo.lastname)

--- a/jo_libs/modules/framework-bridge/cores/redemrp_2023/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/redemrp_2023/server.lua
@@ -357,7 +357,11 @@ end
 
 ---@return number jobGrade player's job grade
 function jo.framework.UserClass:getJobGrade()
-  return self.data.PlayerData.jobgrade
+  return self.data.jobgrade
+end
+
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.SetJob(job) and self.data.SetJobGrade(grade)
 end
 
 ---@return string name player's name

--- a/jo_libs/modules/framework-bridge/cores/redemrp_old/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/redemrp_old/server.lua
@@ -80,6 +80,15 @@ function jo.framework.UserClass:getJob()
   return self.data.getJob()
 end
 
+---@return number jobGrade player's job grade
+function jo.framework.UserClass:getJobGrade()
+  return self.data.getJobgrade()
+end
+
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.setJob(job) and self.data.setJobGrade(grade)
+end
+
 ---@return string name player's name
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(GetValue(self.data.firstname, ""), GetValue(self.data.lastname, ""))

--- a/jo_libs/modules/framework-bridge/cores/rpx-core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/rpx-core/server.lua
@@ -85,6 +85,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.PlayerData.job.rank
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.setJob(job, grade)
+end
+
 ---@return string name player's name
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.PlayerData.charinfo.firstname, self.data.PlayerData.charinfo.lastname)

--- a/jo_libs/modules/framework-bridge/cores/rsg-core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/rsg-core/server.lua
@@ -350,6 +350,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.job.grade.level
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.Functions.SetJob(job, grade)
+end
+
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.PlayerData.charinfo.firstname, self.data.PlayerData.charinfo.lastname)
 end

--- a/jo_libs/modules/framework-bridge/cores/rsg-core_v2/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/rsg-core_v2/server.lua
@@ -350,6 +350,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.job.grade.level
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.Functions.SetJob(job, grade)
+end
+
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.PlayerData.charinfo.firstname, self.data.PlayerData.charinfo.lastname)
 end

--- a/jo_libs/modules/framework-bridge/cores/tpz_core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/tpz_core/server.lua
@@ -44,6 +44,10 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.getJobGrade()
 end
 
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.setJob(job) and self.data.setJobGrade(grade)
+end
+
 function jo.framework.UserClass:getGroup()
   return self.data.getGroup()
 end

--- a/jo_libs/modules/framework-bridge/cores/vorp_core/server.lua
+++ b/jo_libs/modules/framework-bridge/cores/vorp_core/server.lua
@@ -307,6 +307,13 @@ function jo.framework.UserClass:getJobGrade()
   return self.data.jobGrade
 end
 
+---@param job string
+---@param grade number
+---@return boolean success
+function jo.framework.UserClass:setJob(job, grade)
+  return self.data.setJob(job) and self.data.setJobGrade(grade)
+end
+
 ---@return string name
 function jo.framework.UserClass:getRPName()
   return ("%s %s"):format(self.data.firstname, self.data.lastname)


### PR DESCRIPTION
Adds function `setJob(name, grade)` to all frameworks, which allows to set a job and grade.
```lua
--- Sets the current job assigned to a player
---@param job string (The name of the job)
---@param grade number (The grade of the job)
---@return boolean (If job assignment was successful)
function jo.framework.UserClass:setJob(job, grade)
  return false
end
```

Example VORP:
```lua
---@param job string
---@param grade number
---@return boolean success
function jo.framework.UserClass:setJob(job, grade)
  return self.data.setJob(job) and self.data.setJobGrade(grade)
end
```