### PR TITLE
fix(emit) jo.emit.triggerServer metatable __call invocation

### DIFF
--- a/jo_libs/modules/emit/client.lua
+++ b/jo_libs/modules/emit/client.lua
@@ -45,6 +45,7 @@ jo.emit.triggerServer = setmetatable({
     triggerServer(...)
   end
 })
+
 --- A function to check if an event is currently getting data with emit module
 ---@param eventName string the event name
 function jo.emit.isEventInProgress(eventName)

--- a/jo_libs/modules/emit/client.lua
+++ b/jo_libs/modules/emit/client.lua
@@ -41,9 +41,10 @@ end
 jo.emit.triggerServer = setmetatable({
   latent = triggerServerLatent
 }, {
-  __call = triggerServer
+  __call = function(_, ...)
+    triggerServer(...)
+  end
 })
-
 --- A function to check if an event is currently getting data with emit module
 ---@param eventName string the event name
 function jo.emit.isEventInProgress(eventName)


### PR DESCRIPTION
# Fix jo.emit.triggerServer metatable __call invocation
## Summary

Fixes an issue where jo.emit.triggerServer(eventName, ...) failed to trigger server events while jo.emit.triggerServer.latent(eventName, ...) worked as expected.

## Cause

The __call metamethod forwards the table itself as the first argument. As a result, triggerServer received the metatable instance instead of the event name, causing TriggerServerEventInternal to be called with an invalid first argument.

###  Changes
Wrap the __call metamethod to discard the implicit table argument before forwarding the remaining arguments to triggerServer.
Keep the public API unchanged:
jo.emit.triggerServer(eventName, ...)
jo.emit.triggerServer.latent(eventName, ...)
Result

Both triggerServer and triggerServer.latent now behave consistently and correctly trigger their respective server events.