### PR TITLE
feat(inventory): add GM Inventory support

### DIFF
--- a/jo_libs/modules/framework-bridge/inventories/detector_shared.lua
+++ b/jo_libs/modules/framework-bridge/inventories/detector_shared.lua
@@ -64,5 +64,11 @@ return {
     name = "OX Inventory",
     folder = "ox_inventory",
     matchResources = { "ox_inventory" }
+  },
+  {
+    id = "gm",
+    name = "GM Inventory",
+    folder = "gm_inventory",
+    matchResources = { "gm_inventory" }
   }
 }

--- a/jo_libs/modules/framework-bridge/inventories/gm_inventory/g_shared.lua
+++ b/jo_libs/modules/framework-bridge/inventories/gm_inventory/g_shared.lua
@@ -1,0 +1,15 @@
+
+function jo.framework:getInventoryItems()
+  local itemsGM = exports.gm_inventory:Items()
+
+  local items = {}
+  for id, item in pairs(itemsGM) do
+    items[id] = {
+      item = id,
+      label = item.label,
+      description = item.description,
+      image = "nui://gm_inventory/web/images/" .. item.name .. ".png"
+    }
+  end
+  return items
+end

--- a/jo_libs/modules/framework-bridge/inventories/gm_inventory/server.lua
+++ b/jo_libs/modules/framework-bridge/inventories/gm_inventory/server.lua
@@ -1,0 +1,114 @@
+local RSGCore = exports["rsg-core"]:GetCoreObject()
+local useGMInventory = GetResourceState("gm_inventory") == "started"
+
+jo.framework.inv = Inventory
+local inventories = {}
+
+-------------
+-- INVENTORY
+-------------
+
+---@param source integer source ID
+---@param item string name of the item
+---@param amount integer amount to use
+---@param meta table metadata of the item
+---@param remove boolean if removed after used
+function jo.framework:canUseItem(source, item, amount, meta, remove)
+  local count = exports.gm_inventory:GetItem(source, item, meta, true)
+  if not count then
+    count = 0
+  end
+  if count >= amount then
+    if remove then
+      local res = exports.gm_inventory:RemoveItem(source, item, amount, meta)
+      return res
+    end
+  end
+  return false
+end
+
+---@param item string name of the item
+---@param callback function function fired when the item is used
+---@param closeAfterUsed boolean if inventory needs to be closes
+---@return boolean
+function jo.framework:registerUseItem(item, closeAfterUsed, callback)
+  if type(closeAfterUsed) == "function" then
+    callback = closeAfterUsed
+    closeAfterUsed = true
+  end
+  if not useGMInventory then
+    local isAdded = RSGCore.Functions.AddItem(item, nil)
+    if isAdded then
+      return eprint(item .. " < item does not exist in the core configuration")
+    end
+  end
+  RSGCore.Functions.CreateUseableItem(item, function(source, data)
+    callback(source, { metadata = data.info })
+    if closeAfterUsed and not useGMInventory then
+      TriggerClientEvent("rsg-inventory:client:closeInv", source)
+    end
+  end)
+end
+
+---@param source integer source ID
+---@param item string name of the item
+---@param quantity integer quantity
+---@param meta table metadata of the item
+---@return boolean
+function jo.framework:giveItem(source, item, quantity, meta)
+  if exports.gm_inventory:CanCarryItem(source, item, quantity, meta) then
+    local res = exports.gm_inventory:AddItem(source, item, quantity, meta)
+    return res
+  end
+  return false
+end
+
+---@param invName string unique ID of the inventory
+---@param name string name of the inventory
+---@param invConfig table Configuration of the inventory
+---@return boolean
+function jo.framework:createInventory(invName, name, invConfig)
+  local inventoryConfig = {
+    id = invName,
+    name = name,
+    slots = invConfig.maxSlots,
+    maxWeight = invConfig.maxWeight * 1000,
+  }
+  inventories[invName] = inventoryConfig
+  exports.gm_inventory:RegisterStash(inventoryConfig.id, inventoryConfig.name, inventoryConfig.slots, inventoryConfig.maxWeight)
+  return true
+end
+
+---@param invName string unique ID of the inventory
+---@return boolean
+function jo.framework:removeInventory(invName)
+  return exports.gm_inventory:RemoveInventory(invName)
+end
+
+---@param source integer sourceIdentifier
+---@param invName string name of the inventory
+---@return boolean
+function jo.framework:openInventory(source, invName)
+  TriggerClientEvent("ox_inventory:openInventory", source, "stash", { id = invName })
+  return true
+end
+
+---@param invId string unique ID of the inventory
+---@param item string name of the item
+---@param quantity integer quantity
+---@param metadata table metadata of the item
+---@param needWait? boolean wait after the adding
+---@return boolean
+function jo.framework:addItemInInventory(source, invId, item, quantity, metadata, needWait)
+  return exports.gm_inventory:AddItem(invId, item, quantity, metadata)
+end
+
+---@param invId string name of the inventory
+---@return table
+function jo.framework:getItemsFromInventory(invId)
+  return exports.gm_inventory:GetInventoryItems(invId)
+end
+
+-------------
+-- END INVENTORY
+-------------


### PR DESCRIPTION
## Add GM Inventory support

Adds [gm_inventory](https://github.com/gaming-multiverse/gm_inventory) as a supported inventory system in the framework-bridge.

### Changes
- Registered the detector added a `gm` entry to `detector_shared.lua` so the framework auto-detects `gm_inventory` when the resource is started.
- Added a new `gm_inventory` bridge implementing the standard inventory interface:
  - `g_shared.lua` — `getInventoryItems()`, mapping GM's item list into the common format (id, label, description, NUI image path).
  - `server.lua` — server-side operations (`canUseItem`, `registerUseItem`, `giveItem`, `createInventory`, `removeInventory`, `openInventory`, `addItemInInventory`, `getItemsFromInventory`) wired to the `gm_inventory` exports, with `rsg-core` used for useable-item registration.